### PR TITLE
Added hover effect to more items

### DIFF
--- a/public/views/correspondentDevices.html
+++ b/public/views/correspondentDevices.html
@@ -23,10 +23,10 @@
 
   <section class="middle tab-bar-section">
    	<div class="mtabset">
-    	<div class="mtab-title" ng-click="$parent.mtab = 1" ng-class="{'active': mtab == 1}" ng-style="{'color': noColor ? '#4A90E2' : index.backgroundColor}" translate>
+    	<div class="mtab-title hovereffect" ng-click="$parent.mtab = 1" ng-class="{'active': mtab == 1}" ng-style="{'color': noColor ? '#4A90E2' : index.backgroundColor}" translate>
     		Contacts
     	</div>
-    	<div class="mtab-title" ng-click="$parent.mtab = 2" ng-class="{'active': mtab == 2}" ng-style="{'color': noColor ? '#4A90E2' : index.backgroundColor}" translate>
+    	<div class="mtab-title hovereffect" ng-click="$parent.mtab = 2" ng-class="{'active': mtab == 2}" ng-style="{'color': noColor ? '#4A90E2' : index.backgroundColor}" translate>
     		Bot Store
     	</div>
     </div>
@@ -38,7 +38,7 @@
 	<div class="m20b tab-view tab-in" ng-show="state.is('correspondentDevices')" id="chat">
 		<div class="mtab" ng-class="{'active': mtab == 1}" ng-init="mtab = 1">
 		      <ul class="no-bullet m0 correspondentList" ng-init="readList()">
-		        <li class="p10 line-b" ng-repeat="correspondent in list | orderBy:newMsgByAddressComparator">
+		        <li class="p10 line-b hovereffect" ng-repeat="correspondent in list | orderBy:newMsgByAddressComparator">
 		          <a ng-show="selectedCorrespondentList[correspondent.device_address]" 
 		            ng-hide="hideRemoveButton(correspondent.removable)"
 		            class="removeCorrespondentList" 
@@ -73,13 +73,13 @@
 	    </div>
 	    <div class="mtab" ng-class="{'active': mtab == 2}">
 	    	 <ul class="no-bullet m0 correspondentList">
-		        <li class="p10 line-b" ng-repeat="bot in bots">
-		          <div ng-click="showBot(bot)" class="pointer"> 
+               <div ng-click="showBot(bot)" ng-repeat="bot in bots" class="pointer">
+		        <li class="p10 line-b hovereffect" >
 		            {{bot.name}}
 		            <div class="right text-gray"><i class="icon-arrow-right3 size-24" ng-show="!editCorrespondentList && hideRemove"></i></div>
 		            <div class="right label tu radius light-gray" ng-if="bot.isPaired" translate style="margin-top: 5px">Added</div>
-		          </div>
-		        </li>
+		         </li>
+               </div>
 		      </ul>
 		      <div class="text-warning size-12 m10b" ng-show="botsError">{{botsError|translate}}</div>
 	    </div>

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -148,7 +148,7 @@
             ng-style="{'background-color':index.backgroundColor}">{{ (index.alias || index.walletName) | limitTo: 1}}
           </div>
           <div class="right">
-            <a ng-click="$root.go('preferences')" class="button outline round light-gray tiny preferences-icon m0" ng-if="!index.shared_address">
+            <a ng-click="$root.go('preferences')" class="button outline round light-gray tiny preferences-icon m0 hovereffect" ng-if="!index.shared_address">
               <i class="fi-widget size-18 vm wallet-settings"></i>
               <span class="show-for-medium-up" translate>Preferences</span>
             </a>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -810,6 +810,10 @@ table tbody tr:last-child td {
   color: #6D7884;
 }
 
+.hovereffect:hover{
+ background: #EFEFEF;
+}
+
 /*////////////////////////////  BUTTON OUTLINE  ////////////////////////////*/
 
 .button.outline,
@@ -843,14 +847,17 @@ button.outline.dark-gray:focus {
 }
 
 .button.outline.light-gray,
-.button.outline.light-gray:hover,
 .button.outline.light-gray:focus,
 button.outline.light-gray,
-button.outline.light-gray:hover,
 button.outline.light-gray:focus {
   background-color: transparent;
   border: 1px solid #CED5DC;
   color: #7A8C9E;
+}
+
+.button.outline.light-gray:hover,
+button.outline.light-gray:hover {
+  background-color: #EFEFEF;
 }
 
 .button.outline.white,

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -248,6 +248,11 @@ ul.copayer-list img {
   border-top: 3px solid #122232;
 }
 
+.bottombar-item a:hover {
+  color: #D5D9DC;
+
+}
+
 .bottombar-item a.active {
   color: #E4E8EC;
   background-color: #122232;
@@ -405,6 +410,11 @@ ul.correspondentList li a.removeCorrespondentList {
   background: #E4E8EC;
   line-height: 24px;
 }
+
+ul.off-canvas-list li a:hover {
+    color: #D0DBE6;
+}
+
 
 /*
  * Remove all vendors hover / shadow / fade


### PR DESCRIPTION
I find that a hover effect makes the UI look more responsive and helps the user to see on what he will click. So here I propose to add more hover effects: bottom bar, wallet preferences icon, global setting menu and chat selection.

![bildschirmfoto_2017-06-30_18-04-52](https://user-images.githubusercontent.com/29467787/27746204-8fc7eb14-5dc6-11e7-8ab8-3440a6b448e4.png)
![bildschirmfoto_2017-06-30_18-04-59](https://user-images.githubusercontent.com/29467787/27746207-91592470-5dc6-11e7-90a2-25e621ab6cd5.png)
![bildschirmfoto_2017-06-30_18-05-07](https://user-images.githubusercontent.com/29467787/27746210-92bc563e-5dc6-11e7-9d67-867cae8fe185.png)
![bildschirmfoto_2017-06-30_18-05-35](https://user-images.githubusercontent.com/29467787/27746212-942ee1d0-5dc6-11e7-9fcf-4ee8fe650a17.png)
![bildschirmfoto_2017-06-30_18-05-46](https://user-images.githubusercontent.com/29467787/27746213-95ab6a92-5dc6-11e7-8a76-ff6a6fbd5cd2.png)
