### PR TITLE
Configurable use of change addresses

### DIFF
--- a/angular-bitcore-wallet-client/bitcore-wallet-client/lib/api.js
+++ b/angular-bitcore-wallet-client/bitcore-wallet-client/lib/api.js
@@ -540,12 +540,18 @@ API.prototype.sendMultiPayment = function(opts, cb) {
 		Wallet.sendMultiPayment(opts, cb);
 	}
 	else{
-		// create a new change address or select first unused one
-		walletDefinedByKeys.issueOrSelectNextChangeAddress(self.credentials.walletId, function(objAddr){
+		var cont = function(objAddr){
 			opts.change_address = objAddr.address;
 			opts.wallet = self.credentials.walletId;
 			Wallet.sendMultiPayment(opts, cb);
-		});
+		};
+		if (opts.noChangeAddresses)
+			walletDefinedByKeys.readAddresses(self.credentials.walletId, { limit: 1 }, function (arr) {
+				cont(arr[0]);
+			});
+		else
+			// create a new change address or select first unused one
+			walletDefinedByKeys.issueOrSelectNextChangeAddress(self.credentials.walletId, cont);
 	}
 };
 

--- a/public/views/preferencesGlobal.html
+++ b/public/views/preferencesGlobal.html
@@ -52,6 +52,10 @@
       </div>
       <div translate>Unit for blackbytes</div>
     </li>
+    <li>
+      <switch id="use-change-addresses" ng-model="useChangeAddresses" class="green right"></switch>
+      <div translate>Plain wallets use change addresses</div>
+    </li>
   </ul>
 
   <div ng-show="index.usePushNotifications">

--- a/src/js/controllers/preferencesGlobal.js
+++ b/src/js/controllers/preferencesGlobal.js
@@ -14,6 +14,7 @@ angular.module('copayApp.controllers').controller('preferencesGlobalController',
       this.deviceName = config.deviceName;
       this.myDeviceAddress = require('byteballcore/device.js').getMyDeviceAddress();
       this.hub = config.hub;
+      $scope.useChangeAddresses = !!config.useChangeAddresses;
       this.currentLanguageName = uxLanguage.getCurrentLanguageName();
       this.torEnabled = conf.socksHost && conf.socksPort;
       $scope.pushNotifications = config.pushNotifications.enabled;
@@ -72,9 +73,15 @@ angular.module('copayApp.controllers').controller('preferencesGlobalController',
       }
     });
 
+    var unwatchUseChangeAddresses = $scope.$watch('useChangeAddresses', function(val) {
+      configService.set({useChangeAddresses: val}, function (err) {
+	console.log(err);
+      });
+    });
 
     $scope.$on('$destroy', function() {
         unwatchPushNotifications();
         unwatchEncrypt();
+        unwatchUseChangeAddresses();
     });
   });

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -15,6 +15,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
   $rootScope.wpInputFocused = false;
   var config = configService.getSync();
   var configWallet = config.wallet;
+  var useChangeAddresses = config.useChangeAddresses;
   var indexScope = $scope.index;
   $scope.currentSpendUnconfirmed = configWallet.spendUnconfirmed;
     
@@ -820,6 +821,8 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
 					arrSigningDeviceAddresses: arrSigningDeviceAddresses,
 					recipient_device_address: recipient_device_address
 				};
+				if (useChangeAddresses === false)
+					opts.noChangeAddresses = true;
 				fc.sendMultiPayment(opts, function(err){
 					// if multisig, it might take very long before the callback is called
 					indexScope.setOngoingProcess(gettext('sending'), false);

--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -29,6 +29,7 @@ angular.module('copayApp.services').factory('configService', function(storageSer
 	},
 
 	hub: (constants.alt === '2' && isTestnet) ? 'byteball.org/bb-test' : 'byteball.org/bb',
+	useChangeAddresses: true,
 
 	// requires bluetooth permission on android
 	//deviceName: /*isCordova ? cordova.plugins.deviceName.name : */require('os').hostname(),
@@ -169,6 +170,8 @@ angular.module('copayApp.services').factory('configService', function(storageSer
 		  }
 		  if (!_config.hub)
 			  _config.hub = defaultConfig.hub;
+		  if (_config.useChangeAddresses !== !!_config.useChangeAddresses)
+			  _config.useChangeAddresses = defaultConfig.useChangeAddresses;
 		  if (!_config.deviceName)
 			  _config.deviceName = defaultConfig.getDeviceName();
 


### PR DESCRIPTION
Make it possible for the end-user to choose if change addresses should
be used for his plain wallets.  We default to the status quo, which is
to use change addresses.