### PR TITLE
Recursive mkdir for .desktop file (fixed #183)

### DIFF
--- a/src/js/services/fileSystem.js
+++ b/src/js/services/fileSystem.js
@@ -6,6 +6,7 @@ angular.module('copayApp.services')
 		bFsInitialized = false;
 	
 	var fs = require('fs' + '');
+	var pathLib = require('path' + '');
 	try {
 		var desktopApp = require('byteballcore/desktop_app.js' + '');
 	} catch (e) {
@@ -192,6 +193,26 @@ angular.module('copayApp.services')
 		else {
 			return desktopApp.getAppDataDir();
 		}
+	};
+
+	root.recursiveMkdir = function(path, mode, callback) {
+		var parentDir = pathLib.dirname(path);
+		
+		fs.stat(parentDir, function(err, stats) {
+			if (err && err.code !== 'ENOENT')
+				throw Error("failed to stat dir: "+err);
+
+			if (err && err.code === 'ENOENT') {
+				root.recursiveMkdir(parentDir, mode, function(err) {
+					if (err)
+						callback(err);
+					else
+						fs.mkdir(path, mode, callback);
+				});
+			} else {
+				fs.mkdir(path, mode, callback);
+			}
+		});
 	};
 	
 	return root;

--- a/src/js/services/go.js
+++ b/src/js/services/go.js
@@ -2,7 +2,7 @@
 
 var eventBus = require('byteballcore/event_bus.js');
 
-angular.module('copayApp.services').factory('go', function($window, $rootScope, $location, $state, profileService, nodeWebkit, notification, gettextCatalog, authService, $deepStateRedirect, $stickyState) {
+angular.module('copayApp.services').factory('go', function($window, $rootScope, $location, $state, profileService, fileSystemService, nodeWebkit, notification, gettextCatalog, authService, $deepStateRedirect, $stickyState) {
 	var root = {};
 
 	var hideSidebars = function() {
@@ -167,7 +167,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 		var child_process = require('child_process'+'');
 		var package = require('../package.json'+''); // relative to html root
 		var applicationsDir = process.env.HOME + '/.local/share/applications';
-		fs.mkdir(applicationsDir, parseInt('700', 8), function(err){
+		fileSystemService.recursiveMkdir(applicationsDir, parseInt('700', 8), function(err){
 			console.log('mkdir applications: '+err);
 			fs.writeFile(applicationsDir + '/' +package.name+'.desktop', "[Desktop Entry]\n\
 Type=Application\n\


### PR DESCRIPTION
This pull request creates fileSystemService.recursiveMkdir and uses it to create ~/.local/share for the .desktop file. This fixes #183 