### PR TITLE
Incorrect description in security warning

### DIFF
--- a/public/views/preferencesEmail.html
+++ b/public/views/preferencesEmail.html
@@ -35,7 +35,7 @@
     <input type="submit" class="button expand black round" value="{{'Save'|translate}}"
     ng-style="{'background-color':index.backgroundColor}" ng-disabled="emailForm.$invalid && !index.preferencesGlobal.preferencesEmail">
   </form>
-    <div class="text-gray size-12 text-center" translate>Setting up email notifications could weaken your privacy, if the wallet service provider is compromised. Information available to an attacker would include your wallet addresses and its balance, but no more.
+    <div class="text-gray size-12 text-center" translate>Setting up email notifications could weaken your privacy, if the email service provider is compromised. Information available to an attacker would include your wallet addresses and its balance, but no more.
   </div>
 </div>
 <div class="extra-margin-bottom"></div>


### PR DESCRIPTION
"wallet service provider" should rightfully be "email service provider", since users could be lead to believe their wallet is hosted by a service provider. In fact, the security risk is with the email service provider.