### PR TITLE
fix crash when no particular asset in wallet

### DIFF
--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1548,8 +1548,10 @@ angular.module('copayApp.controllers')
 					var assetIndex = lodash.findIndex($scope.index.arrBalances, {
 						asset: asset
 					});
-					if (assetIndex < 0)
-						throw Error("failed to find asset index of asset " + asset);
+					if (assetIndex < 0) {
+						notification.error("failed to find asset index of asset " + asset);
+						return self.resetForm();
+					}
 					$scope.index.assetIndex = assetIndex;
 					this.lockAsset = true;
 				}


### PR DESCRIPTION
Steps to reproduce:
1. make a payment request URI with the asset you don't have, for example:
`byteball:YOUR_ADDRESS?amount=1&asset=IYzTSjJg4I3hvUaRXrihRm9+mSEShenPK8l8uKUOD3o=`
2. click on the link

Result: wallet crashes if you don't have that asset.