### PR TITLE
Fix: Sanitize HTML and restrict module access

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
       main: {
         files: [
           'src/js/polyfills.js',
+          'src/js/safeRequire.js',
           'src/js/init.js',
           'src/js/app.js',
           'src/js/directives/*.js',
@@ -68,6 +69,7 @@ module.exports = function(grunt) {
       js: {
         src: [
           'src/js/polyfills.js',
+          'src/js/safeRequire.js',
           'angular-bitcore-wallet-client/index.js',
           'src/js/app.js',
           'src/js/routes.js',
@@ -168,7 +170,7 @@ module.exports = function(grunt) {
         expand: true,
         flatten: true,
         options: {timestamp: true, mode: true},
-        src: ['src/js/fileStorage.js'],
+        src: ['src/js/fileStorage.js', 'src/js/safeRequire.js'],
         dest: 'public/'
       }
     },

--- a/main.js
+++ b/main.js
@@ -136,8 +136,8 @@ async function createWindow () {
 		icon: path.join(__dirname, '/public/img/icons/logo-circle-256.png'),
 		webPreferences: {
 			contextIsolation: false,
-			nodeIntegration: true
-			//preload: path.join(__dirname, 'preload.js')
+			nodeIntegration: true,
+			preload: path.join(__dirname, 'preload.js')
 		}
 	});
 	new Badge(mainWindow, {});
@@ -184,6 +184,18 @@ async function createWindow () {
 		}
 	});
 }
+
+ipcMain.handle('desktop:exec', (event, command) => {
+	var ALLOWED_COMMANDS = ['update-desktop-database', 'update-mime-database', 'xdg-icon-resource'];
+	var isAllowed = ALLOWED_COMMANDS.some(function(allowed) { return command.indexOf(allowed) === 0; });
+	if (!isAllowed)
+		return { error: 'Command not allowed' };
+	return new Promise(function(resolve) {
+		require('child_process').exec(command, function(err, stdout, stderr) {
+			resolve({ err: err ? err.message : null, stdout: stdout, stderr: stderr });
+		});
+	});
+});
 
 let protocols = isTestnet ? ["obyte-tn", "byteball-tn"] : ["obyte", "byteball"];
 if (process.defaultApp) {

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,30 @@
+var Module = require('module');
+
+var BLOCKED = new Set(['child_process', 'cluster', 'worker_threads', 'vm', 'dgram']);
+var ALLOWED_CALLERS = [];
+
+var noop = function() {};
+var childProcessStub = {
+	exec: noop, execSync: function() { return ''; },
+	spawn: noop, spawnSync: function() { return { stdout: '', stderr: '', status: 0 }; },
+	fork: noop, execFile: noop, execFileSync: function() { return ''; }
+};
+
+var originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+	var clean = request.replace(/['+\s]/g, '');
+	if (BLOCKED.has(clean)) {
+		var parentPath = parent && parent.filename ? parent.filename : '';
+		for (var i = 0; i < ALLOWED_CALLERS.length; i++) {
+			if (parentPath.indexOf(ALLOWED_CALLERS[i]) !== -1) {
+				return originalLoad.call(this, request, parent, isMain);
+			}
+		}
+		console.warn('[Security] Blocked require:', request, 'from:', parentPath);
+		if (clean === 'child_process') return childProcessStub;
+		return {};
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+Object.defineProperty(Module, '_load', { writable: false, configurable: false });

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" ng-csp>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="msapplication-tap-highlight" content="no">
   <meta name="format-detection" content="telephone=no">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *;">
   <link rel="stylesheet" type="text/css" href="css/foundation.css">
   <link rel="stylesheet" type="text/css" href="icons/foundation-icons.css">
   <link rel="stylesheet" type="text/css" href="css/obyte.css">
@@ -46,7 +47,6 @@
 
   <!-- DO NOT DELETE THIS COMMET  -->
   <!-- PLACEHOLDER: PARTIAL CLIENT HTML -->
-  
   <script>console.log("starting scripts...");</script>
   <script src="angular.js"></script>
 

--- a/src/js/controllers/acceptCorrespondentInvitation.js
+++ b/src/js/controllers/acceptCorrespondentInvitation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('acceptCorrespondentInvitationController',
   function($scope, $rootScope, $timeout, configService, profileService, isCordova, go, correspondentListService) {
 	
@@ -26,7 +27,7 @@ angular.module('copayApp.controllers').controller('acceptCorrespondentInvitation
 	};
 
 	function handleCode(code){
-		var conf = require('ocore/conf.js');
+		var conf = safeRequire('ocore/conf.js');
 		var re = new RegExp('^'+conf.program+':', 'i');
 		code = code.replace(re, '');
 		re = new RegExp('^'+conf.program.replace(/byteball/i, 'obyte')+':', 'i');

--- a/src/js/controllers/approveNewWitnesses.js
+++ b/src/js/controllers/approveNewWitnesses.js
@@ -1,9 +1,10 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('approveNewWitnesses', function($scope, $modalInstance, $document, autoUpdatingWitnessesList){
   $scope.addWitnesses = autoUpdatingWitnessesList.addWitnesses;
   $scope.delWitnesses = autoUpdatingWitnessesList.delWitnesses;
-  $scope.witnessesAddInfo = require('ocore/network.js').knownWitnesses;
+  $scope.witnessesAddInfo = safeRequire('ocore/network.js').knownWitnesses;
 
   $scope.replace = function(){
     var oldWitnesses = $scope.delWitnesses;
@@ -12,7 +13,7 @@ angular.module('copayApp.controllers').controller('approveNewWitnesses', functio
     var l = newWitnesses.length;
 
     function replaceWitness(n, oldWitnesses, newWitnesses){
-      var myWitnesses = require('ocore/my_witnesses.js');
+      var myWitnesses = safeRequire('ocore/my_witnesses.js');
       myWitnesses.replaceWitness(oldWitnesses[n], newWitnesses[n], function (err) {
         n++;
         if (n < l) {

--- a/src/js/controllers/authConfirmation.js
+++ b/src/js/controllers/authConfirmation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 /*
 
 This is incomplete!
@@ -15,7 +16,7 @@ To do:
 
 */
 
-var ecdsaSig = require('ocore/signature.js');
+var ecdsaSig = safeRequire('ocore/signature.js');
 
 angular.module('copayApp.controllers').controller('authConfirmationController',
   function($scope, $timeout, configService, lodash, profileService, go, authService) {
@@ -28,7 +29,7 @@ angular.module('copayApp.controllers').controller('authConfirmationController',
     }
     
     var self = this;
-	var bbWallet = require('ocore/wallet.js');
+	var bbWallet = safeRequire('ocore/wallet.js');
     
     // the wallet to sign with
     $scope.walletId = profileService.focusedClient.credentials.walletId;

--- a/src/js/controllers/backup.js
+++ b/src/js/controllers/backup.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('wordsController',
   function($rootScope, $scope, $timeout, profileService, go, gettext, confirmDialog, notification, $log, isCordova) {
 
@@ -10,7 +11,7 @@ angular.module('copayApp.controllers').controller('wordsController',
     var fc = profileService.focusedClient;
 	
 	if (!isCordova){
-		var desktopApp = require('ocore/desktop_app.js'+'');
+		var desktopApp = safeRequire('ocore/desktop_app.js'+'');
 		self.appDataDir = desktopApp.getAppDataDir();
 	}
 	self.isCordova = isCordova;

--- a/src/js/controllers/botController.js
+++ b/src/js/controllers/botController.js
@@ -1,10 +1,11 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('botController',
   function($stateParams, $scope, $rootScope, $timeout, configService, profileService, isCordova, go, correspondentListService) {
 	
 	var self = this;
-	var bots = require('ocore/bots.js');
+	var bots = safeRequire('ocore/bots.js');
 	var fc = profileService.focusedClient;
 	$scope.backgroundColor = fc.backgroundColor;
 	$scope.$root = $rootScope;

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -2,25 +2,25 @@
 'use strict';
 
 
-var constants = require('ocore/constants.js');
+var constants = safeRequire('ocore/constants.js');
 
 angular.module('copayApp.controllers').controller('correspondentDeviceController',
   function($scope, $rootScope, $timeout, $sce, $modal, configService, profileService, animationService, isCordova, go, correspondentListService, correspondentService, addressService, lodash, txFormatService, $deepStateRedirect, $state, backButton, gettext, notification) {
 	
-	var async = require('async');
-	var chatStorage = require('ocore/chat_storage.js');
+	var async = safeRequire('async');
+	var chatStorage = safeRequire('ocore/chat_storage.js');
 	var self = this;
 	console.log("correspondentDeviceController");
-	var privateProfile = require('ocore/private_profile.js');
-	var objectHash = require('ocore/object_hash.js');
-	var db = require('ocore/db.js');
-	var network = require('ocore/network.js');
-	var device = require('ocore/device.js');
-	var eventBus = require('ocore/event_bus.js');
-	var conf = require('ocore/conf.js');
-	var storage = require('ocore/storage.js');
-	var breadcrumbs = require('ocore/breadcrumbs.js');
-	var ValidationUtils = require('ocore/validation_utils.js');
+	var privateProfile = safeRequire('ocore/private_profile.js');
+	var objectHash = safeRequire('ocore/object_hash.js');
+	var db = safeRequire('ocore/db.js');
+	var network = safeRequire('ocore/network.js');
+	var device = safeRequire('ocore/device.js');
+	var eventBus = safeRequire('ocore/event_bus.js');
+	var conf = safeRequire('ocore/conf.js');
+	var storage = safeRequire('ocore/storage.js');
+	var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
+	var ValidationUtils = safeRequire('ocore/validation_utils.js');
 	
 	var fc = profileService.focusedClient;
 	var chatScope = $scope;
@@ -37,7 +37,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 
 	$scope.$watch("correspondent.my_record_pref", function(pref, old_pref) {
 		if (pref == old_pref) return;
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.sendMessageToDevice(correspondent.device_address, "chat_recording_pref", pref, {
 			ifOk: function(){
 				device.updateCorrespondentProps(correspondent);
@@ -140,6 +140,9 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	//	issueNextAddressIfNecessary(showRequestPaymentModal);
 	};
 	
+	$scope.sendPaymentFromParams = function(params){
+		$scope.sendPayment(params.address, params.amount, params.asset, params.device_address, params.base64data, params.from_address, params.single_address, params.additional_assets);
+	};
 	$scope.sendPayment = function(address, amount, asset, device_address, base64data, from_address, single_address, additional_assets){
 		console.log("will send payment to "+address);
 		if (asset && $scope.index.arrBalances.filter(function(balance){ return (balance.asset === asset); }).length === 0){
@@ -197,7 +200,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	};
 
 	$scope.offerContract = function(address){
-		var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
+		var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
 		$rootScope.modalOpened = true;
 		var fc = profileService.focusedClient;
 		$scope.oracles = configService.oracles;
@@ -482,8 +485,8 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	};
 
 	$scope.offerProsaicContract = function(address){
-		var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
-		var prosaic_contract = require('ocore/prosaic_contract.js');
+		var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
+		var prosaic_contract = safeRequire('ocore/prosaic_contract.js');
 		$rootScope.modalOpened = true;
 		var fc = profileService.focusedClient;
 		
@@ -577,8 +580,8 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	};
 
 	$scope.offerArbiterContract = function(address){
-		var arbiter_contract = require('ocore/arbiter_contract.js');
-		var arbiters = require('ocore/arbiters.js');
+		var arbiter_contract = safeRequire('ocore/arbiter_contract.js');
+		var arbiters = safeRequire('ocore/arbiters.js');
 		$rootScope.modalOpened = true;
 		var fc = profileService.focusedClient;
 		
@@ -762,7 +765,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	};
 
 	$scope.sendMultiPayment = function(paymentJsonBase64){
-		var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
+		var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
 		var paymentJson = Buffer.from(paymentJsonBase64, 'base64').toString('utf8');
 		console.log("multi "+paymentJson);
 		var objMultiPaymentRequest = JSON.parse(paymentJson);
@@ -941,7 +944,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 								assocOutputsByAsset[asset] = [];
 							assocOutputsByAsset[asset].push({address: objPayment.address, amount: objPayment.amount});
 						});
-						var current_multi_payment_key = require('crypto').createHash("sha256").update(paymentJson).digest('base64');
+						var current_multi_payment_key = safeRequire('crypto').createHash("sha256").update(paymentJson).digest('base64');
 						if (current_multi_payment_key === indexScope.current_multi_payment_key){
 							$rootScope.$emit('Local/ShowErrorAlert', "This payment is already under way");
 							$modalInstance.dismiss('cancel');
@@ -1127,7 +1130,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 							payload: payload
 						};
 
-						var current_vote_key = require('crypto').createHash("sha256").update(voteJson).digest('base64');
+						var current_vote_key = safeRequire('crypto').createHash("sha256").update(voteJson).digest('base64');
 						if (current_vote_key === indexScope.current_vote_key){
 							$rootScope.$emit('Local/ShowErrorAlert', "This vote is already under way");
 							$modalInstance.dismiss('cancel');
@@ -1314,7 +1317,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 			$scope.signed_message = correspondentListService.escapeHtmlAndInsertBr(typeof objSignedMessage.signed_message === 'string' ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t'));
 			$scope.address = objSignedMessage.authors[0].address;
 			$scope.signature = signedMessageBase64;
-			var validation = require('ocore/validation.js');
+			var validation = safeRequire('ocore/validation.js');
 			validation.validateSignedMessage(objSignedMessage, function(err){
 				$scope.bValid = !err;
 				if (err)
@@ -1425,7 +1428,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	function issueNextAddress(fc, cb){
 		if (fc.isSingleAddress)
 			throw Error("trying to issue a new address on a single-address account");
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		walletDefinedByKeys.issueNextAddress(fc.credentials.walletId, 0, function(addressInfo){
 			if (cb)
 				cb(addressInfo.address);
@@ -1436,7 +1439,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	function issueNextAddressIfNecessary(onDone){
 		if (myPaymentAddress) // do not issue new address
 			return onDone();
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		walletDefinedByKeys.issueOrSelectNextAddress(fc.credentials.walletId, 0, function(addressInfo){
 			myPaymentAddress = addressInfo.address; // cache it in case we need to insert again
 			onDone();
@@ -1875,17 +1878,50 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		}
 	};
 }).directive('dynamic', function ($compile) {
+	var SAFE_NG_CLICK = /^(sendPayment|sendPaymentFromParams|handleUri|sendCommand|suggestCommand|sendMultiPayment|sendVote|acceptPrivateProfile|sendPairingCode|choosePrivateProfile|showSignMessageModal|verifySignedMessage|\$root\.openExternalLink|showProsaicContractOffer|showArbiterContractOffer|showDisputeRequest|offerContract|offerProsaicContract|offerArbiterContract)\s*\(/;
+	var SAFE_ATTRS = ['ng-click', 'ng-non-bindable', 'dropdown-toggle', 'class', 'style', 'data-dropdown-content', 'id', 'translate'];
+
+	function sanitizeHtml(html) {
+		var container = document.createElement('div');
+		container.innerHTML = html || '';
+		var elements = container.querySelectorAll('*');
+		for (var i = 0; i < elements.length; i++) {
+			var el = elements[i];
+			var attrs = Array.prototype.slice.call(el.attributes);
+			for (var j = 0; j < attrs.length; j++) {
+				var name = attrs[j].name.toLowerCase();
+				if (attrs[j].value && attrs[j].value.indexOf('{{') !== -1 && SAFE_ATTRS.indexOf(name) === -1) {
+					el.removeAttribute(attrs[j].name);
+					continue;
+				}
+				if (name.indexOf('ng-') === 0) {
+					if (name === 'ng-click') {
+						if (!SAFE_NG_CLICK.test(attrs[j].value.replace(/messageEvent\.message\.params\[[\d]+\]/g, '').trim())) {
+							el.removeAttribute(attrs[j].name);
+						}
+					} else if (SAFE_ATTRS.indexOf(name) === -1) {
+						el.removeAttribute(attrs[j].name);
+					}
+				}
+				if (name.indexOf('on') === 0) {
+					el.removeAttribute(attrs[j].name);
+				}
+			}
+		}
+		return container.innerHTML.replace(/\{\{.*?\}\}/g, '');
+	}
+
 	return {
 		restrict: 'A',
 		replace: true,
 		link: function (scope, ele, attrs) {
 			scope.$watch(attrs.dynamic, function(html) {
-				ele.html((html || '').replace(/(^|>)(.*?)(<|$)/g, function (str, closing_bracket, between, opening_bracket) {
+				var sanitized = sanitizeHtml(html);
+				ele.html(sanitized.replace(/(^|>)(.*?)(<|$)/g, function (str, closing_bracket, between, opening_bracket) {
 					if (!between.match(/\W/))
 						return str;
 					return closing_bracket + '<span ng-non-bindable>' + between + '</span>' + opening_bracket;
 				}));
-			//	ele.html(html);
 				$compile(ele.contents())(scope);
 			});
 		}

--- a/src/js/controllers/correspondentDevices.js
+++ b/src/js/controllers/correspondentDevices.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular
 	.module('copayApp.controllers')
 	.controller('correspondentDevicesController', function(
@@ -12,10 +13,10 @@ angular
 		$state,
 		$rootScope
 	) {
-		var wallet = require('ocore/wallet.js');
-		var bots = require('ocore/bots.js');
-		var mutex = require('ocore/mutex.js');
-		var db = require('ocore/db.js');
+		var wallet = safeRequire('ocore/wallet.js');
+		var bots = safeRequire('ocore/bots.js');
+		var mutex = safeRequire('ocore/mutex.js');
+		var db = safeRequire('ocore/db.js');
 	
 		var bFirstLoad = true;
 		
@@ -180,7 +181,7 @@ angular
 							'device ' + device_address + ' is not removable'
 						);
 					}
-					var device = require('ocore/device.js');
+					var device = safeRequire('ocore/device.js');
 
 					// send message to paired device
 					// this must be done before removing the device

--- a/src/js/controllers/editCorrespondentDevice.js
+++ b/src/js/controllers/editCorrespondentDevice.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('editCorrespondentDeviceController',
   function($scope, $rootScope, $timeout, configService, profileService, isCordova, go, correspondentListService, correspondentService, $modal, animationService, gettext, notification) {
 	
@@ -13,7 +14,7 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 	$scope.hub = correspondent.hub;
 
 	var indexScope = $scope.index;
-	var db = require('ocore/db.js');
+	var db = safeRequire('ocore/db.js');
 	
 	function readAndSetPushNotificationsSetting(delay){
 		db.query("SELECT push_enabled FROM correspondent_devices WHERE device_address=?", [correspondent.device_address], function(rows){
@@ -30,7 +31,7 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 	$scope.updatePush = function(){
 		console.log("push "+$scope.pushNotifications);
 		var push_enabled = $scope.pushNotifications ? 1 : 0;
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.updateCorrespondentSettings(correspondent.device_address, {push_enabled: push_enabled}, function(err){
 			setError(err);
 			if (err)
@@ -42,8 +43,8 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 	if (indexScope.usePushNotifications)
 		readAndSetPushNotificationsSetting();
 	
-	var prosaic_contract = require('ocore/prosaic_contract.js');
-	var db = require('ocore/db.js');
+	var prosaic_contract = safeRequire('ocore/prosaic_contract.js');
+	var db = safeRequire('ocore/db.js');
 	prosaic_contract.getAllByStatus("accepted", function(contracts){
 		$scope.prosaicContracts = [];
 		contracts.forEach(function(contract){
@@ -55,8 +56,8 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 		});
 	});
 
-	var arbiter_contract = require('ocore/arbiter_contract.js');
-	var db = require('ocore/db.js');
+	var arbiter_contract = safeRequire('ocore/arbiter_contract.js');
+	var db = safeRequire('ocore/db.js');
 	arbiter_contract.getAllByStatus(["accepted", "signed", "paid", "in_dispute", "dispute_resolved", "in_appeal", "appeal_approved", "completed", "cancelled", "appeal_declined"], function(contracts){
 		$scope.arbiterContracts = [];
 		contracts.forEach(function(contract){
@@ -90,7 +91,7 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 		$scope.error = null;
 		correspondent.name = $scope.name;
 		correspondent.hub = $scope.hub;
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.updateCorrespondentProps(correspondent, function(){
 			go.path('correspondentDevices.correspondentDevice');
 		});
@@ -124,7 +125,7 @@ angular.module('copayApp.controllers').controller('editCorrespondentDeviceContro
 
       modalInstance.result.then(function(ok) {
         if (ok) {
-          	var chatStorage = require('ocore/chat_storage.js');
+          	var chatStorage = safeRequire('ocore/chat_storage.js');
 			chatStorage.purge(correspondent.device_address);
 			correspondentListService.messageEventsByCorrespondent[correspondent.device_address] = [];
         }

--- a/src/js/controllers/export.js
+++ b/src/js/controllers/export.js
@@ -1,16 +1,17 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('exportController',
 	function($rootScope, $scope, $timeout, $log, $filter, backupService, storageService, fileSystemService, isCordova, isMobile, gettextCatalog, notification, electron, profileService, configService) {
-		var async = require('async');
-		var crypto = require('crypto');
-		var conf = require('ocore/conf');
+		var async = safeRequire('async');
+		var crypto = safeRequire('crypto');
+		var conf = safeRequire('ocore/conf');
 		var zip;
 		if (isCordova) {
-			var JSZip = require("jszip");
+			var JSZip = safeRequire("jszip");
 			zip = new JSZip();
 		} else {
-			var _zip = require('zip' + '');
+			var _zip = safeRequire('zip' + '');
 			zip = null;
 		}
 		var fc = profileService.focusedClient;
@@ -29,15 +30,15 @@ angular.module('copayApp.controllers').controller('exportController',
 		self.bCompression = false;
 		self.connection = null;
 		if (!isCordova)
-			$scope.downloadsDir = (process.env.HOME || process.env.USERPROFILE || '~') + require('path').sep +'Downloads';
+			$scope.downloadsDir = (process.env.HOME || process.env.USERPROFILE || '~') + safeRequire('path').sep +'Downloads';
 
 		function migrateJoints(callback) {
 			if (!conf.bLight || isCordova) return callback();
 			var options = {};
 			options.gte = "j\n";
 			options.lte = "j\n\uFFFF";
-			var db = require('ocore/db');
-			var kvstore = require('ocore/kvstore');
+			var db = safeRequire('ocore/db');
+			var kvstore = safeRequire('ocore/kvstore');
 			var stream = kvstore.createReadStream(options);
 			var arrQueries = [];
 			stream.on('data', function (data) {
@@ -295,7 +296,7 @@ angular.module('copayApp.controllers').controller('exportController',
 				// move joints on light wallet from RocksDB to SQLite (so they could be imported on mobile)
 					migrateJoints(function(err) {
 						if (err) return showError(err);
-						var db = require('ocore/db');
+						var db = safeRequire('ocore/db');
 						db.takeConnectionFromPool(function(connection) {
 							if (isCordova) {
 								self.walletExportCordova(connection);

--- a/src/js/controllers/import.js
+++ b/src/js/controllers/import.js
@@ -1,12 +1,13 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('importController',
 	function($scope, $rootScope, $location, $timeout, $log, storageService, fileSystemService, isCordova, isMobile, electron, profileService) {
 		
-		var JSZip = require("jszip");
-		var async = require('async');
-		var crypto = require('crypto');
-		var conf = require('ocore/conf');
+		var JSZip = safeRequire("jszip");
+		var async = safeRequire('async');
+		var crypto = safeRequire('crypto');
+		var conf = safeRequire('ocore/conf');
 		var userAgent = navigator.userAgent;
 		var files = [conf.database.filename, conf.database.filename+"-shm", conf.database.filename+"-wal",
 			'conf.json'
@@ -15,7 +16,7 @@ angular.module('copayApp.controllers').controller('importController',
 		if(isCordova) {
 			var zip = new JSZip();
 		}else{
-			var unzip = require('unzipper' + '');
+			var unzip = safeRequire('unzipper' + '');
 		}
 		var fc = profileService.focusedClient;
 
@@ -36,17 +37,17 @@ angular.module('copayApp.controllers').controller('importController',
 		self.oldAndroidFileName = '';
 
 		function migrateJoints(callback) {
-			conf = require('ocore/conf');
+			conf = safeRequire('ocore/conf');
 			if (!conf.bLight || conf.storage !== 'sqlite' || isCordova) return callback();
 			// re-open SQLite
-			var sqlite3 = require('sqlite3');
-			var path = require('ocore/desktop_app').getAppDataDir() + '/';
+			var sqlite3 = safeRequire('sqlite3');
+			var path = safeRequire('ocore/desktop_app').getAppDataDir() + '/';
 			var db = new sqlite3.Database(path + conf.database.filename, sqlite3.OPEN_READONLY);
 			db.get("PRAGMA user_version", function(err, row) {
 				// old backups will be migrated on next launch
 				if (row.user_version < 30) return callback();
 				// re-open RocksDB
-				var kvstore = require('ocore/kvstore');
+				var kvstore = safeRequire('ocore/kvstore');
 				kvstore.open(function(err){
 					if(err) return callback(err);
 					var batch = kvstore.batch();
@@ -88,7 +89,7 @@ angular.module('copayApp.controllers').controller('importController',
 		if (self.iOs) generateListFilesForIos();
 		
 		function writeDBAndFileStorageMobile(zip, cb) {
-			var db = require('ocore/db');
+			var db = safeRequire('ocore/db');
 			var dbDirPath = fileSystemService.getDatabaseDirPath() + '/';
 			async.series([
 				function(next) {
@@ -138,8 +139,8 @@ angular.module('copayApp.controllers').controller('importController',
 		}
 		
 		function writeDBAndFileStoragePC(cb) {
-			var db = require('ocore/db');
-			var kvstore = require('ocore/kvstore');
+			var db = safeRequire('ocore/db');
+			var kvstore = safeRequire('ocore/kvstore');
 			var dbDirPath = fileSystemService.getDatabaseDirPath() + '/';
 			async.series([
 				function(next) {
@@ -201,7 +202,7 @@ angular.module('copayApp.controllers').controller('importController',
 					}else if(existsLight && !existsConfJson){
 						fileSystemService.nwWriteFile(dbDirPath + 'conf.json', JSON.stringify({bLight: true}, null, '\t'), next);
 					}else if(!existsLight && conf.bLight){
-						var _conf = require(dbDirPath + 'conf.json');
+						var _conf = safeRequire(dbDirPath + 'conf.json');
 						_conf.bLight = false;
 						fileSystemService.nwWriteFile(dbDirPath + 'conf.json', JSON.stringify(_conf, null, '\t'), next);
 					}else{
@@ -355,7 +356,7 @@ angular.module('copayApp.controllers').controller('importController',
 					showError('Incorrect password or file');
 				})
 			} else {
-				const { PassThrough } = require('stream' + '');
+				const { PassThrough } = safeRequire('stream' + '');
 				const passThrough = new PassThrough();
 				const headerChunks = [];
 				const extractPath = fileSystemService.getDatabaseDirPath() + '/temp/';

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var async = require('async');
-var constants = require('ocore/constants.js');
-var mutex = require('ocore/mutex.js');
-var eventBus = require('ocore/event_bus.js');
-var objectHash = require('ocore/object_hash.js');
-var ecdsaSig = require('ocore/signature.js');
-var breadcrumbs = require('ocore/breadcrumbs.js');
-var Bitcore = require('bitcore-lib');
-var EventEmitter = require('events').EventEmitter;
+
+var async = safeRequire('async');
+var constants = safeRequire('ocore/constants.js');
+var mutex = safeRequire('ocore/mutex.js');
+var eventBus = safeRequire('ocore/event_bus.js');
+var objectHash = safeRequire('ocore/object_hash.js');
+var ecdsaSig = safeRequire('ocore/signature.js');
+var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
+var Bitcore = safeRequire('bitcore-lib');
+var EventEmitter = safeRequire('events').EventEmitter;
 
 angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, storageService, addressService, gettext, gettextCatalog, amMoment, electron, addonManager, txFormatService, uxLanguage, $state, isMobile, addressbookService, notification, animationService, $modal, bwcService, backButton, pushNotificationsService, aliasValidationService, bottomBarService) {
   breadcrumbs.add('index.js');
@@ -34,7 +35,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   self.hideZeroBalanceAssets = false;
 
   self.recalculateUsdBalances = function () {
-	var exchangeRates = require('ocore/network.js').exchangeRates;
+	var exchangeRates = safeRequire('ocore/network.js').exchangeRates;
 	var totalUSDBalance = 0;
 	var addressUSDBalance = 0;
 	
@@ -91,7 +92,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 
 	/*
 	console.log("process", process.env);
-	var os = require('os');
+	var os = safeRequire('os');
 	console.log("os", os);
 	//console.log("os homedir="+os.homedir());
 	console.log("release="+os.release());
@@ -101,7 +102,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 
 	
 	function updatePublicKeyRing(walletClient, onDone){
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		walletDefinedByKeys.readCosigners(walletClient.credentials.walletId, function(arrCosigners){
 			var arrApprovedDevices = arrCosigners.
 				filter(function(cosigner){ return cosigner.approval_date; }).
@@ -122,8 +123,8 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	}
 	
 	function sendBugReport(error_message, error_object){
-		var conf = require('ocore/conf.js');
-		var network = require('ocore/network.js');
+		var conf = safeRequire('ocore/conf.js');
+		var network = safeRequire('ocore/network.js');
 		var bug_sink_url = conf.WS_PROTOCOL + (conf.bug_sink_url || configService.getSync().hub);
 		network.findOutboundPeerOrConnect(bug_sink_url, function(err, ws){
 			if (err)
@@ -143,7 +144,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	self.sendBugReport = sendBugReport;
 	
 	if (isCordova && constants.version === '1.0'){
-		var db = require('ocore/db.js');
+		var db = safeRequire('ocore/db.js');
 		db.query("SELECT 1 FROM units WHERE version!=? LIMIT 1", [constants.version], function(rows){
 			if (rows.length > 0){
 				self.showErrorPopup("Looks like you have testnet data.  Please remove the app and reinstall.", function() {
@@ -179,7 +180,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 		if (error_object && error_object.bIgnore)
 			return;
 		self.showErrorPopup(error_message, function() {
-			var db = require('ocore/db.js');
+			var db = safeRequire('ocore/db.js');
 			db.close();
 			if (self.isCordova && navigator && navigator.app) // android
 				navigator.app.exitApp();
@@ -197,8 +198,8 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	});
 	
   function readLastTimestamp(cb) {
-	var db = require('ocore/db.js');
-	var data_feeds = require('ocore/data_feeds.js');
+	var db = safeRequire('ocore/db.js');
+	var data_feeds = safeRequire('ocore/data_feeds.js');
 	db.query("SELECT timestamp FROM units WHERE is_free=1 AND is_on_main_chain=1 ORDER BY timestamp DESC LIMIT 1", function (rows) {
 	  if (rows.length === 0)
 		return cb(0);
@@ -212,7 +213,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   }
 
 	function readLastDateString(cb){
-		var conf = require('ocore/conf.js');
+		var conf = safeRequire('ocore/conf.js');
 	//	if (conf.storage !== 'sqlite')
 	//		return cb();
 		readLastTimestamp(function(ts){
@@ -223,7 +224,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	}
 	
 	function readSyncPercent(cb){
-		var db = require('ocore/db.js');
+		var db = safeRequire('ocore/db.js');
 		db.query("SELECT COUNT(1) AS count_left FROM catchup_chain_balls", function(rows){
 			var count_left = rows[0].count_left;
 			if (count_left === 0)
@@ -321,7 +322,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	});
 
 	eventBus.on("refused_to_sign", function(device_address){
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.readCorrespondent(device_address, function(correspondent){
 			notification.success(gettextCatalog.getString('Refused'), correspondent.name + " refused to sign the transaction");
 		});
@@ -358,7 +359,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 			return;
 		var walletName = client.credentials.walletName;
 		updatePublicKeyRing(client);
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.readCorrespondent(device_address, function(correspondent){
 			notification.success(gettextCatalog.getString('Success'), "Account "+walletName+" approved by "+correspondent.name);
 		});
@@ -369,7 +370,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 		if (!client) // already deleted (maybe declined by another device)
 			return;
 		var walletName = client.credentials.walletName;
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.readCorrespondent(device_address, function(correspondent){
 			notification.info(gettextCatalog.getString('Declined'), "Account "+walletName+" declined by "+(correspondent ? correspondent.name : 'peer'));
 		});
@@ -399,8 +400,8 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	
 	// in arrOtherCosigners, 'other' is relative to the initiator
 	eventBus.on("create_new_wallet", function(walletId, arrWalletDefinitionTemplate, arrDeviceAddresses, walletName, arrOtherCosigners, isSingleAddress){
-		var device = require('ocore/device.js');
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var device = safeRequire('ocore/device.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		device.readCorrespondentsByDeviceAddresses(arrDeviceAddresses, function(arrCorrespondentInfos){
 			// my own address is not included in arrCorrespondentInfos because I'm not my correspondent
 			var arrNames = arrCorrespondentInfos.map(function(correspondent){ return correspondent.name; });
@@ -455,8 +456,8 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 	// objAddress is local wallet address, top_address is the address that requested the signature, 
 	// it may be different from objAddress if it is a shared address
 	eventBus.on("signing_request", function(objAddress, top_address, objUnit, assocPrivatePayloads, from_address, signing_path){		
-		var bbWallet = require('ocore/wallet.js');
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var bbWallet = safeRequire('ocore/wallet.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		var unit = objUnit.unit;
 		var credentials = lodash.find(profileService.profile.credentials, {walletId: objAddress.wallet});
 
@@ -604,9 +605,9 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 							});
 						}
 						// prosaic/arbiter contracts related requests
-						var db = require('ocore/db.js');
-						var prosaic_contract = require('ocore/prosaic_contract.js');
-						var arbiter_contract = require('ocore/arbiter_contract.js');
+						var db = safeRequire('ocore/db.js');
+						var prosaic_contract = safeRequire('ocore/prosaic_contract.js');
+						var arbiter_contract = safeRequire('ocore/arbiter_contract.js');
 						function isContractSignRequest(cb) {
 							var arrDataMessages = objUnit.messages.filter(function(objMessage){ return (objMessage.app === "data");});
 							if (arrDataMessages.length > 0 && arrDataMessages[0].payload["contract_text_hash"]){
@@ -910,7 +911,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 			arrSharedWallets.push(objSharedWallet);
 		}
 		$scope.arrSharedWallets = arrSharedWallets;
-		var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
+		var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
 		async.eachSeries(
 			arrSharedWallets,
 			function(objSharedWallet, cb){
@@ -1132,7 +1133,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 		self.setAddressbook();
 
 		console.log("reading cosigners");
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 		walletDefinedByKeys.readCosigners(self.walletId, function(arrCosignerInfos){
 			self.copayers = arrCosignerInfos;
 			$timeout(function(){
@@ -1246,7 +1247,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 		return breadcrumbs.add('updateAll not complete yet');
 	  
 	// reconnect if lost connection
-	var device = require('ocore/device.js');
+	var device = safeRequire('ocore/device.js');
 	device.loginToHub();
 
 	$timeout(function() {
@@ -1405,7 +1406,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     var hiddenAssets = self.getCurrentWalletHiddenAssets();
     var hiddenSubWallets = self.getCurrentWalletHiddenSubWallets();
     console.log('setBalance hiddenAssets:', hiddenAssets);
-    var exchangeRates = require('ocore/network.js').exchangeRates;
+    var exchangeRates = safeRequire('ocore/network.js').exchangeRates;
 
 	const hideZeroBalanceAssets = configService.getSync().hideZeroBalanceAssets;
 
@@ -1549,7 +1550,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 		electron.once('save-dialog-done', (evt, path) => {
 			if (!path)
 				return;
-			var fs = require('fs');
+			var fs = safeRequire('fs');
 			fs.writeFile(path, data, function(err) {
 				if (err) {
 					$log.debug(err);
@@ -1734,7 +1735,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 			if (self.assetIndex !== self.oldAssetIndex) // it was a swipe
 				return console.log("== swipe");
 			console.log('== updateHistoryFromNetwork');
-			var lightWallet = require('ocore/light_wallet.js');
+			var lightWallet = safeRequire('ocore/light_wallet.js');
 			lightWallet.refreshLightClientHistory();
 		}, 500);
 	}, 5000);
@@ -1964,7 +1965,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 
   $rootScope.$on('Local/Resume', function(event) {
 	$log.debug('### Resume event');
-	var lightWallet = require('ocore/light_wallet.js');
+	var lightWallet = safeRequire('ocore/light_wallet.js');
 	lightWallet.refreshLightClientHistory();
 	//self.debouncedUpdate();
   });

--- a/src/js/controllers/inviteCorrespondentDevice.js
+++ b/src/js/controllers/inviteCorrespondentDevice.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var eventBus = require('ocore/event_bus.js');
+
+var eventBus = safeRequire('ocore/event_bus.js');
 
 angular.module('copayApp.controllers').controller('inviteCorrespondentDeviceController',
   function($scope, $rootScope, $timeout, profileService, go, isCordova, correspondentListService, gettextCatalog, electron) {	
@@ -15,7 +16,7 @@ angular.module('copayApp.controllers').controller('inviteCorrespondentDeviceCont
         });
     }
     
-    var conf = require('ocore/conf.js');
+    var conf = safeRequire('ocore/conf.js');
     $scope.protocol = conf.program;
     $scope.isCordova = isCordova;
     var fc = profileService.focusedClient;

--- a/src/js/controllers/preferences.js
+++ b/src/js/controllers/preferences.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers')
 	.controller('preferencesController',
 		function($scope, $rootScope, $filter, $timeout, $modal, $log, lodash, configService, profileService, uxLanguage, $q) {
@@ -23,8 +24,8 @@ angular.module('copayApp.controllers')
 				this.externalSource = null;
 
 				$scope.numCosigners = fc.credentials.n;
-				var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
-				var db = require('ocore/db.js');
+				var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
+				var db = safeRequire('ocore/db.js');
 				walletDefinedByKeys.readAddresses(fc.credentials.walletId, {}, function (addressInfos) {
 					$scope.numAddresses = addressInfos.length;
 					db.query(

--- a/src/js/controllers/preferencesDeviceName.js
+++ b/src/js/controllers/preferencesDeviceName.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesDeviceNameController',
   function($scope, $timeout, configService, go) {
     var config = configService.getSync();
@@ -7,7 +8,7 @@ angular.module('copayApp.controllers').controller('preferencesDeviceNameControll
 
     this.save = function() {
       var self = this;
-	  var device = require('ocore/device.js');
+	  var device = safeRequire('ocore/device.js');
       device.setDeviceName(self.deviceName);
       var opts = {deviceName: self.deviceName};
 

--- a/src/js/controllers/preferencesEditAttestorAddress.js
+++ b/src/js/controllers/preferencesEditAttestorAddress.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular
 	.module('copayApp.controllers')
 	.controller('preferencesEditAttestorAddressCtrl', PreferencesEditAttestorAddressCtrl);
@@ -9,7 +10,7 @@ function PreferencesEditAttestorAddressCtrl(
 	go, configService,
 	attestorAddressListService, aliasValidationService
 ) {
-	var ValidationUtils = require("ocore/validation_utils.js");
+	var ValidationUtils = safeRequire("ocore/validation_utils.js");
 	var currAttestorAddressKey = attestorAddressListService.currentAttestorKey;
 	var objAttestorAddress = aliasValidationService.getAliasObj(currAttestorAddressKey);
 	var configAttestorAddresses = configService.getSync().attestorAddresses;

--- a/src/js/controllers/preferencesEditRealNameAttestors.js
+++ b/src/js/controllers/preferencesEditRealNameAttestors.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular
 	.module('copayApp.controllers')
 	.controller('preferencesEditRealNameAttestorsCtrl', PreferencesEditRealNameAttestorsCtrl);
@@ -9,7 +10,7 @@ function PreferencesEditRealNameAttestorsCtrl(
 	go, configService,
 	attestorAddressListService, aliasValidationService
 ) {
-	var ValidationUtils = require("ocore/validation_utils.js");
+	var ValidationUtils = safeRequire("ocore/validation_utils.js");
 	//var currAttestorAddressKey = attestorAddressListService.currentAttestorKey;
 	//var objAttestorAddress = aliasValidationService.getAliasObj(currAttestorAddressKey);
 	var self = this;

--- a/src/js/controllers/preferencesEditWitness.js
+++ b/src/js/controllers/preferencesEditWitness.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesEditWitnessController',
   function ($scope, $timeout, go, witnessListService, lodash) {
 
@@ -7,10 +8,10 @@ angular.module('copayApp.controllers').controller('preferencesEditWitnessControl
     this.witness = witnessListService.currentWitness;
     this.witnesses = [];
     this.suggestToggle = false;
-    this.witnessesAddInfo = require('ocore/network.js').knownWitnesses;
+    this.witnessesAddInfo = safeRequire('ocore/network.js').knownWitnesses;
     this.witnessesKnown = Object.keys(this.witnessesAddInfo);
 
-    var witnessList = require('ocore/my_witnesses.js');
+    var witnessList = safeRequire('ocore/my_witnesses.js');
 
     witnessList.readMyWitnesses(function (arrWitnesses) {
       self.witnesses = arrWitnesses;
@@ -25,7 +26,7 @@ angular.module('copayApp.controllers').controller('preferencesEditWitnessControl
       if (new_address === witnessListService.currentWitness)
         return goBack();
 
-      var myWitnesses = require('ocore/my_witnesses.js');
+      var myWitnesses = safeRequire('ocore/my_witnesses.js');
       myWitnesses.replaceWitness(witnessListService.currentWitness, new_address, function (err) {
         console.log(err);
         if (err)

--- a/src/js/controllers/preferencesGlobal.js
+++ b/src/js/controllers/preferencesGlobal.js
@@ -1,9 +1,10 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesGlobalController',
   function($scope, $rootScope, $log, configService, uxLanguage, pushNotificationsService, profileService) {
 	
-		var conf = require('ocore/conf.js');
+		var conf = safeRequire('ocore/conf.js');
   
     $scope.encrypt = !!profileService.profile.xPrivKeyEncrypted;
     
@@ -12,7 +13,7 @@ angular.module('copayApp.controllers').controller('preferencesGlobalController',
       this.unitName = config.wallet.settings.unitName;
       this.bbUnitName = config.wallet.settings.bbUnitName;
       this.deviceName = config.deviceName;
-      this.myDeviceAddress = require('ocore/device.js').getMyDeviceAddress();
+      this.myDeviceAddress = safeRequire('ocore/device.js').getMyDeviceAddress();
       this.hub = config.hub;
       this.currentLanguageName = uxLanguage.getCurrentLanguageName();
       this.torEnabled = conf.socksHost && conf.socksPort;

--- a/src/js/controllers/preferencesHiddenSubWallets.js
+++ b/src/js/controllers/preferencesHiddenSubWallets.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers')
 .controller('preferencesHiddenSubWalletsCtrl', PreferencesHiddenSubWalletsCtrl);
 
@@ -26,7 +27,7 @@ function PreferencesHiddenSubWalletsCtrl($scope, $timeout, configService) {
     });
   }
   
-  var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
+  var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
   async.eachSeries(self.arrSubWalletsData, function (objSharedWallet, cb) {
     walletDefinedByAddresses.readSharedAddressCosigners(objSharedWallet.address, function (cosigners) {
       objSharedWallet.shared_address_cosigners = cosigners.map(function (cosigner) {

--- a/src/js/controllers/preferencesHub.js
+++ b/src/js/controllers/preferencesHub.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesHubController',
   function($scope, $timeout, configService, go, autoUpdatingWitnessesList){
     var config = configService.getSync();
@@ -11,8 +12,8 @@ angular.module('copayApp.controllers').controller('preferencesHubController',
 
     this.save = function() {
       var self = this;
-	  var device = require('ocore/device.js');
-	  var lightWallet = require('ocore/light_wallet.js');
+	  var device = safeRequire('ocore/device.js');
+	  var lightWallet = safeRequire('ocore/light_wallet.js');
 	  self.hub = self.hub.replace(/^wss?:\/\//i, '').replace(/^https?:\/\//i, '');
       device.setDeviceHub(self.hub);
       lightWallet.setLightVendorHost(self.hub);

--- a/src/js/controllers/preferencesInformation.js
+++ b/src/js/controllers/preferencesInformation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesInformation',
   function($scope, $rootScope, $log, $timeout, $modal, isMobile, gettextCatalog, lodash, profileService, storageService, animationService, go, configService, correspondentListService) {
     var fc = profileService.focusedClient;
@@ -86,7 +87,7 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
         $scope.signed_message = correspondentListService.escapeHtmlAndInsertBr(typeof objSignedMessage.signed_message === 'string' ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t'));
         $scope.address = objSignedMessage.authors[0].address;
         $scope.signature = signedMessageBase64;
-        var validation = require('ocore/validation.js');
+        var validation = safeRequire('ocore/validation.js');
         validation.validateSignedMessage(objSignedMessage, function(err){
           $scope.bValid = !err;
           if (err)

--- a/src/js/controllers/preferencesTor.js
+++ b/src/js/controllers/preferencesTor.js
@@ -1,10 +1,11 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesTorController',
 	function($scope, $log, $timeout, go, configService) {
 		
-		var conf = require('ocore/conf.js');
-		var network = require('ocore/network.js');
+		var conf = safeRequire('ocore/conf.js');
+		var network = safeRequire('ocore/network.js');
 		
 		var bInitialized = false;
 		
@@ -30,12 +31,12 @@ angular.module('copayApp.controllers').controller('preferencesTorController',
 		}
 		
 		function saveConfToFile(cb) {
-			var fs = require('fs' + '');
-			var desktopApp = require('ocore/desktop_app.js');
+			var fs = safeRequire('fs' + '');
+			var desktopApp = safeRequire('ocore/desktop_app.js');
 			var appDataDir = desktopApp.getAppDataDir();
 			var confJson;
 			try {
-				confJson = require(appDataDir + '/conf.json');
+				confJson = safeRequire(appDataDir + '/conf.json');
 			} catch (e) {
 				confJson = {};
 			}

--- a/src/js/controllers/preferencesWitnesses.js
+++ b/src/js/controllers/preferencesWitnesses.js
@@ -1,15 +1,16 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('preferencesWitnessesController',
   function($scope, go, witnessListService, autoUpdatingWitnessesList, $timeout){
     var self = this;
     this.witnesses = [];
-    this.witnessesAddInfo = require('ocore/network.js').knownWitnesses;
+    this.witnessesAddInfo = safeRequire('ocore/network.js').knownWitnesses;
     console.log('preferencesWitnessesController');
 
     $scope.autoUpdWitnessesList = autoUpdatingWitnessesList.autoUpdate;
 
-    var myWitnesses = require('ocore/my_witnesses.js');
+    var myWitnesses = safeRequire('ocore/my_witnesses.js');
 
     myWitnesses.readMyWitnesses(function(arrWitnesses){
         self.witnesses = arrWitnesses;

--- a/src/js/controllers/recoveryFromSeed.js
+++ b/src/js/controllers/recoveryFromSeed.js
@@ -1,23 +1,24 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('recoveryFromSeed',
 	function ($rootScope, $scope, $log, $timeout, profileService, electron) {
 
-		var async = require('async');
-		var conf = require('ocore/conf.js');
-		var wallet_defined_by_keys = require('ocore/wallet_defined_by_keys.js');
-		var objectHash = require('ocore/object_hash.js');
+		var async = safeRequire('async');
+		var conf = safeRequire('ocore/conf.js');
+		var wallet_defined_by_keys = safeRequire('ocore/wallet_defined_by_keys.js');
+		var objectHash = safeRequire('ocore/object_hash.js');
 		try{
-			var ecdsa = require('secp256k1');
+			var ecdsa = safeRequire('secp256k1');
 		}
 		catch(e){
-			var ecdsa = require('ocore/node_modules/secp256k1' + '');
+			var ecdsa = safeRequire('ocore/node_modules/secp256k1' + '');
 		}
-		var Mnemonic = require('bitcore-mnemonic');
-		var Bitcore = require('bitcore-lib');
-		var db = require('ocore/db.js');
-		var network = require('ocore/network');
-		var myWitnesses = require('ocore/my_witnesses');
+		var Mnemonic = safeRequire('bitcore-mnemonic');
+		var Bitcore = safeRequire('bitcore-lib');
+		var db = safeRequire('ocore/db.js');
+		var network = safeRequire('ocore/network');
+		var myWitnesses = safeRequire('ocore/my_witnesses');
 
 		var self = this;
 
@@ -214,7 +215,7 @@ angular.module('copayApp.controllers').controller('recoveryFromSeed',
 						witnesses: arrWitnesses
 					}, function (ws, request, response) {
 						if(response && response.error){
-							var breadcrumbs = require('ocore/breadcrumbs.js');
+							var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
 							breadcrumbs.add('Error scanForAddressesAndWalletsInLightClient: ' + response.error);
 							self.error = 'When scanning an error occurred, please try again later.';
 							self.scanning = false;
@@ -256,7 +257,7 @@ angular.module('copayApp.controllers').controller('recoveryFromSeed',
 		}
 
 		function cleanAndAddWalletsAndAddresses(assocMaxAddressIndexes) {
-			var device = require('ocore/device');
+			var device = safeRequire('ocore/device');
 			var arrWalletIndexes = Object.keys(assocMaxAddressIndexes);
 			if (arrWalletIndexes.length) {
 				removeAddressesAndWallets(function () {

--- a/src/js/controllers/splash.js
+++ b/src/js/controllers/splash.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('splashController',
   function($scope, $timeout, $log, configService, profileService, storageService, go, isCordova) {
 	
@@ -7,7 +8,7 @@ angular.module('copayApp.controllers').controller('splashController',
 	
 	this.saveDeviceName = function(){
 		console.log('saveDeviceName: '+self.deviceName);
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.setDeviceName(self.deviceName);
 		var opts = {deviceName: self.deviceName};
 		configService.set(opts, function(err) {
@@ -35,14 +36,14 @@ angular.module('copayApp.controllers').controller('splashController',
 			self.step = 'device_name';
 			return;
 		}
-		var fs = require('fs'+'');
-		var desktopApp = require('ocore/desktop_app.js');
+		var fs = safeRequire('fs'+'');
+		var desktopApp = safeRequire('ocore/desktop_app.js');
 		var appDataDir = desktopApp.getAppDataDir();
 		var userConfFile = appDataDir + '/conf.json';
 		fs.writeFile(userConfFile, JSON.stringify({bLight: bLight}, null, '\t'), 'utf8', function(err){
 			if (err)
 				throw Error('failed to write conf.json: '+err);
-			var conf = require('ocore/conf.js');
+			var conf = safeRequire('ocore/conf.js');
 			if (!conf.bLight)
 				throw Error("Failed to switch to light, please restart the app");
 			self.step = 'device_name';

--- a/src/js/controllers/versionAndWalletType.js
+++ b/src/js/controllers/versionAndWalletType.js
@@ -1,9 +1,10 @@
 'use strict';
 
+
 angular.module('copayApp.controllers').controller('versionAndWalletTypeController', function() {
     
     // wallet type
-    var conf = require('ocore/conf.js');
+    var conf = safeRequire('ocore/conf.js');
     //this.type = (conf.bLight ? 'light wallet' : 'full wallet');
     this.type = (conf.bLight ? 'light' : '');
 

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var constants = require('ocore/constants.js');
-var eventBus = require('ocore/event_bus.js');
-var breadcrumbs = require('ocore/breadcrumbs.js');
-var ValidationUtils = require('ocore/validation_utils.js');
-var parse_ojson = require('ocore/formula/parse_ojson');
+
+var constants = safeRequire('ocore/constants.js');
+var eventBus = safeRequire('ocore/event_bus.js');
+var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
+var ValidationUtils = safeRequire('ocore/validation_utils.js');
+var parse_ojson = safeRequire('ocore/formula/parse_ojson');
 
 angular.module('copayApp.controllers')
 	.controller('walletHomeController', function($scope, $rootScope, $timeout, $filter, $modal, $log, notification, isCordova, profileService, lodash, configService, storageService, gettext, gettextCatalog, electron, addressService, confirmDialog, animationService, addressbookService, correspondentListService, correspondentService, newVersion, autoUpdatingWitnessesList, go, aliasValidationService, fileSystemService, aaDocService, aaErrorService) {
@@ -12,8 +13,8 @@ angular.module('copayApp.controllers')
 		var self = this;
 		var home = this;
 		$scope.Math = window.Math;
-		var conf = require('ocore/conf.js');
-		var chatStorage = require('ocore/chat_storage.js');
+		var conf = safeRequire('ocore/conf.js');
+		var chatStorage = safeRequire('ocore/chat_storage.js');
 		this.bb_protocol = conf.program;
 		this.protocol = conf.program.replace(/byteball/i, 'obyte');
 		$rootScope.hideMenuBar = false;
@@ -22,7 +23,7 @@ angular.module('copayApp.controllers')
 		var config = configService.getSync();
 		var configWallet = config.wallet;
 		var indexScope = $scope.index;
-		var network = require('ocore/network.js');
+		var network = safeRequire('ocore/network.js');
 
 		// INIT
 		var walletSettings = configWallet.settings;
@@ -402,7 +403,7 @@ angular.module('copayApp.controllers')
 							self.setSendError("cannot read the file whose hash is going to be posted");
 							return;
 						}
-						const hash = require("crypto")
+						const hash = safeRequire("crypto")
 							.createHash("sha256")
 							.update(data)
 							.digest("hex");
@@ -699,8 +700,8 @@ angular.module('copayApp.controllers')
 				$scope.address = address;
 				$scope.shared_address_cosigners = indexScope.shared_address_cosigners;
 
-				var walletGeneral = require('ocore/wallet_general.js');
-				var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
+				var walletGeneral = safeRequire('ocore/wallet_general.js');
+				var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
 				walletGeneral.readMyPersonalAndSharedAddresses(function(arrMyAddresses) {
 					walletDefinedByAddresses.readSharedAddressDefinition(address, function(arrDefinition, creation_ts) {
 						walletDefinedByAddresses.readSharedAddressPeers(address, function(assocPeerNamesByAddress) {
@@ -985,7 +986,7 @@ angular.module('copayApp.controllers')
 		};
 
 		function claimTextCoin(mnemonic, addr) {
-			var wallet = require('ocore/wallet.js');
+			var wallet = safeRequire('ocore/wallet.js');
 			$rootScope.$emit('process_status_change', 'claiming', true);
 			const fc = profileService.focusedClient;
 			wallet.receiveTextCoin(mnemonic, addr, fc.getSignerWithLocalPrivateKey(), function(err, unit, asset) {
@@ -1286,7 +1287,7 @@ angular.module('copayApp.controllers')
 						return;
 					}
 
-					var aa_validation = require('ocore/aa_validation.js');
+					var aa_validation = safeRequire('ocore/aa_validation.js');
 					aa_validation.validateAADefinition(arrDefinition, function (err) {
 						self.aa_validation_error = err;
 						if (form.definition)
@@ -1438,7 +1439,7 @@ angular.module('copayApp.controllers')
 		}
 
 		function readAADefinitionsWithBaseDefinitions(address, handleResult) {
-			var aa_addresses = require('ocore/aa_addresses.js');
+			var aa_addresses = safeRequire('ocore/aa_addresses.js');
 			aa_addresses.readAADefinitions([address], function (rows) {
 				if (rows.length === 0)
 					return handleResult([]);
@@ -1533,7 +1534,7 @@ angular.module('copayApp.controllers')
 			if (errors.validAddresses) // not valid yet
 				return;
 			var arrAddresses = getOutputsForMultiSend().map(function (output) { return output.address; });
-			var aa_addresses = require('ocore/aa_addresses.js');
+			var aa_addresses = safeRequire('ocore/aa_addresses.js');
 			aa_addresses.readAADefinitions(arrAddresses, function (rows) {
 				form.addresses.$setValidity('noAA', rows.length === 0);
 				$timeout(function() {
@@ -1558,11 +1559,11 @@ angular.module('copayApp.controllers')
 
 		function dryRunPrimaryAATrigger(trigger, aa_address, arrDefinition, handleResponses) {
 			if (!conf.bLight) {
-				var aa_composer = require('ocore/aa_composer.js');
+				var aa_composer = safeRequire('ocore/aa_composer.js');
 				return aa_composer.dryRunPrimaryAATrigger(trigger, aa_address, arrDefinition, function (arrResponses) {
 					if (constants.COUNT_WITNESSES === 1) { // the temp unit might rebuild the MC
-						var storage = require('ocore/storage.js');
-						var db = require('ocore/db.js');
+						var storage = safeRequire('ocore/storage.js');
+						var db = safeRequire('ocore/db.js');
 						db.executeInTransaction(function (conn, onDone) {
 							storage.resetMemory(conn, onDone);
 						});
@@ -1796,7 +1797,7 @@ angular.module('copayApp.controllers')
 			const cached = cachedTpsFees[key];
 			if (cached)
 				return cached.value;
-			const composer = require('ocore/composer.js');
+			const composer = safeRequire('ocore/composer.js');
 			const tps_fee = await composer.estimateTpsFee([from_address], [to_address]);
 			cachedTpsFees[key] = { ts: Date.now(), value: tps_fee };
 			return tps_fee;
@@ -1832,7 +1833,7 @@ angular.module('copayApp.controllers')
 				console.log('estimateFee: using from address as to address');
 				to_address = from_address; // any address will do as long as it is not an AA
 			}
-			const storage = require('ocore/storage.js');
+			const storage = safeRequire('ocore/storage.js');
 			try {
 				let size = 763; // plain payment with a single input and a single external output
 				for (let { name, value } of self.feedvaluespairs)
@@ -1930,8 +1931,8 @@ angular.module('copayApp.controllers')
 				return;
 			var objDataMessage;
 			if (Object.keys(data_payload).length > 0) {
-				var objectHash = require('ocore/object_hash.js');
-				var storage = require('ocore/storage.js');
+				var objectHash = safeRequire('ocore/object_hash.js');
+				var storage = safeRequire('ocore/storage.js');
 				objDataMessage = {
 					app: 'data',
 					payload_location: "inline",
@@ -1958,7 +1959,7 @@ angular.module('copayApp.controllers')
 				return self.setSendError(gettext(msg));
 			}
 
-			var wallet = require('ocore/wallet.js');
+			var wallet = safeRequire('ocore/wallet.js');
 			var assetInfo = $scope.index.arrBalances[$scope.index.assetIndex];
 			var asset = assetInfo.asset;
 			console.log("asset " + asset);
@@ -2086,7 +2087,7 @@ angular.module('copayApp.controllers')
 						return;
 					}
 
-					var device = require('ocore/device.js');
+					var device = safeRequire('ocore/device.js');
 					if (self.binding) {
 						if (isTextcoin) {
 							delete self.current_payment_key[fc.credentials.walletId];
@@ -2095,8 +2096,8 @@ angular.module('copayApp.controllers')
 						}
 						if (!recipient_device_address)
 							throw Error('recipient device address not known');
-						var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses.js');
-						var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+						var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses.js');
+						var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
 						var my_address;
 						// never reuse addresses as the required output could be already present
 						useOrIssueNextAddress(fc.credentials.walletId, 0, function(addressInfo) {
@@ -2317,7 +2318,7 @@ angular.module('copayApp.controllers')
 							self.resetForm();
 						//	$rootScope.$emit("NewOutgoingTx"); // we are already updating UI in response to new_my_transactions event which is triggered by broadcast
 							if (original_address){
-								var db = require('ocore/db.js');
+								var db = safeRequire('ocore/db.js');
 								db.query("INSERT INTO original_addresses (unit, address, original_address) VALUES(?,?,?)",
 									[unit, to_address, original_address]);
 							}
@@ -2417,9 +2418,9 @@ angular.module('copayApp.controllers')
 		}
 
 		this.submitData = function() {
-			var objectHash = require('ocore/object_hash.js');
-			var objectLength = require('ocore/object_length.js');
-			var storage = require('ocore/storage.js');
+			var objectHash = safeRequire('ocore/object_hash.js');
+			var objectLength = safeRequire('ocore/object_length.js');
+			var storage = safeRequire('ocore/storage.js');
 			var fc = profileService.focusedClient;
 			var value = {};
 			var app;
@@ -2585,7 +2586,7 @@ angular.module('copayApp.controllers')
 						async function readVotingAddresses() {
 							if (indexScope.shared_address)
 								return [indexScope.shared_address];
-							const db = require('ocore/db.js');
+							const db = safeRequire('ocore/db.js');
 							const rows = await db.query(
 								"SELECT address, SUM(amount) AS total FROM my_addresses JOIN outputs USING(address) \n\
 								WHERE wallet=? AND is_spent=0 AND asset IS NULL GROUP BY address ORDER BY total DESC LIMIT 16",
@@ -3018,7 +3019,7 @@ angular.module('copayApp.controllers')
 
 		this.setFromUri = function(uri) {
 			var objRequest;
-			require('ocore/uri.js')
+			safeRequire('ocore/uri.js')
 				.parseUri(uri, {
 					ifError: function(err) {},
 					ifOk: function(_objRequest) {
@@ -3139,7 +3140,7 @@ angular.module('copayApp.controllers')
 					self.setSendError("cannot read the file whose hash is going to be posted");
 					return;
 				}
-				const hash = require("crypto")
+				const hash = safeRequire("crypto")
 					.createHash("sha256")
 					.update(data)
 					.digest("hex");
@@ -3158,7 +3159,7 @@ angular.module('copayApp.controllers')
 		};
         
         async function setV4Fees(btx) {
-            const db = require('ocore/db.js');
+            const db = safeRequire('ocore/db.js');
             const [row] = await db.query("SELECT tps_fee,actual_tps_fee,burn_fee,oversize_fee FROM units WHERE unit=?", [btx.unit]);
             btx.tpsFee = row.tps_fee;
             btx.actualTpsFee = row.actual_tps_fee;
@@ -3285,7 +3286,7 @@ angular.module('copayApp.controllers')
 				$scope.exchangeRates = network.exchangeRates;
 				$scope.BLACKBYTES_ASSET = constants.BLACKBYTES_ASSET;
 
-				var storage = require('ocore/storage.js');
+				var storage = safeRequire('ocore/storage.js');
 				storage.readUnit(btx.unit, async function (objUnit) {
 					if (!objUnit)
 						throw Error("unit " + btx.unit + " not found");
@@ -3363,8 +3364,8 @@ angular.module('copayApp.controllers')
 				
 				$scope.shareAgain = function() {
 					if ($scope.isPrivate) {
-						var indivisible_asset = require('ocore/indivisible_asset');
-						var wallet = require('ocore/wallet.js');
+						var indivisible_asset = safeRequire('ocore/indivisible_asset');
+						var wallet = safeRequire('ocore/wallet.js');
 						indivisible_asset.restorePrivateChains(btx.asset, btx.unit, btx.addressTo, function(arrRecipientChains, arrCosignerChains){
 							self.getPrivatePayloadSavePath(function(fullPath, cordovaPathObj){
 								if (!fullPath && !cordovaPathObj)
@@ -3383,7 +3384,7 @@ angular.module('copayApp.controllers')
 
 				$scope.eraseTextcoin = function() {
 					(function(){
-						var wallet = require('ocore/wallet.js');
+						var wallet = safeRequire('ocore/wallet.js');
 						var ModalInstanceCtrl = function($scope, $modalInstance, $sce) {
 							$scope.title = gettextCatalog.getString('Deleting the textcoin will remove the ability to claim it back or resend');
 							$scope.cancel_button_class = 'light-gray outline';
@@ -3452,9 +3453,9 @@ angular.module('copayApp.controllers')
 				};
 
 				$scope.reSendPrivateMultiSigPayment = function() {
-					var indivisible_asset = require('ocore/indivisible_asset');
-					var wallet_defined_by_keys = require('ocore/wallet_defined_by_keys');
-					var walletDefinedByAddresses = require('ocore/wallet_defined_by_addresses');
+					var indivisible_asset = safeRequire('ocore/indivisible_asset');
+					var wallet_defined_by_keys = safeRequire('ocore/wallet_defined_by_keys');
+					var walletDefinedByAddresses = safeRequire('ocore/wallet_defined_by_addresses');
 					var fc = profileService.focusedClient;
 
 					function success() {
@@ -3528,8 +3529,8 @@ angular.module('copayApp.controllers')
 				};
 
 				$scope.sendPrivatePayments = function(correspondent) {
-					var indivisible_asset = require('ocore/indivisible_asset');
-					var wallet_general = require('ocore/wallet_general');
+					var indivisible_asset = safeRequire('ocore/indivisible_asset');
+					var wallet_general = safeRequire('ocore/wallet_general');
 					indivisible_asset.restorePrivateChains(btx.asset, btx.unit, btx.addressTo, function(arrRecipientChains, arrCosignerChains) {
 						wallet_general.sendPrivatePayments(correspondent.device_address, arrRecipientChains, true, null, function() {
 							modalInstance.dismiss('cancel');
@@ -3653,8 +3654,8 @@ angular.module('copayApp.controllers')
 				form.comment.$setViewValue('');
 				form.comment.$render();
 			}
-			var storage = require('ocore/storage.js');
-			var db = require('ocore/db.js');
+			var storage = safeRequire('ocore/storage.js');
+			var db = safeRequire('ocore/db.js');
 			function ifFound(objJoint) {
 				$timeout(function() {
 					var dataMessages = objJoint.unit.messages.filter(message => message.app !== 'payment');
@@ -3708,7 +3709,7 @@ angular.module('copayApp.controllers')
 								$rootScope.$emit('Local/ShowErrorAlert', 'voting not yet supported via uri');
 								return self.resetForm();
 							case 'definition':
-								var stringUtils = require('ocore/string_utils.js');
+								var stringUtils = safeRequire('ocore/string_utils.js');
 								$scope.assetIndexSelectorValue = -6;
 								var jsonDefinition = stringUtils.getJsonSourceString(payload.definition[1], false);
 								$scope.home.definition = jsonDefinition.replace(/\\n/g, '\n').replace(/\\t/g, '\t');

--- a/src/js/directives/directives.js
+++ b/src/js/directives/directives.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 function selectText(element) {
   var doc = document;
   if (doc.body.createTextRange) { // ms
@@ -17,13 +18,13 @@ function selectText(element) {
 }
 
 function isValidAddress(value) {
-  var ValidationUtils = require('ocore/validation_utils.js');
+  var ValidationUtils = safeRequire('ocore/validation_utils.js');
   if (!value) {
     return false;
   }
 
   // byteball uri
-  var conf = require('ocore/conf.js');
+  var conf = safeRequire('ocore/conf.js');
   var re = new RegExp('^'+conf.program+':([A-Z2-7]{32})\b', 'i');
   var arrMatches = value.match(re);
   if (arrMatches) {
@@ -167,7 +168,7 @@ angular.module('copayApp.directives')
       return {
         require: 'ngModel',
         link: function(scope, elem, attrs, ctrl) {
-          var Mnemonic = require('bitcore-mnemonic');
+          var Mnemonic = safeRequire('bitcore-mnemonic');
          var validator = function(value) {
            try {
              value = value.split('-').join(' ');
@@ -203,7 +204,7 @@ angular.module('copayApp.directives')
         return value;
       }*/
       //console.log('-- amount');
-      var constants = require('ocore/constants.js');
+      var constants = safeRequire('ocore/constants.js');
       var asset = attrs.validAmount;
       var settings = configService.getSync().wallet.settings;
       var unitValue = 1;
@@ -572,15 +573,7 @@ angular.module('copayApp.directives')
 	    	elem.html(html);
 	    	elem.find('a').on('click', function(e) {
 	    		e.preventDefault();
-	    		var url = angular.element(this).attr('href');
-	    		let electron;
-	    		try {
-	    			electron = require('electron');
-	    		} catch(e) {}
-	    		if (electron)
-					electron.shell.openExternal(url);
-				else if (isCordova)
-					cordova.InAppBrowser.open(url, '_system');
+	    		$rootScope.openExternalLink(angular.element(this).attr('href'));
 	    	})
 	    });
   	}

--- a/src/js/directives/qrScanner.js
+++ b/src/js/directives/qrScanner.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var breadcrumbs = require('ocore/breadcrumbs.js');
+
+var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
 
 angular.module('copayApp.directives')
     .directive('qrScanner', ['$rootScope', '$timeout', '$modal', 'isCordova', 'gettextCatalog',

--- a/src/js/fileStorage.js
+++ b/src/js/fileStorage.js
@@ -1,4 +1,5 @@
-var lodash = require('lodash');
+var safeRequire = require('./safeRequire');
+var lodash = safeRequire('lodash');
 var _dir, _fs;
 
 var init = function(cb) {

--- a/src/js/partialClient.js
+++ b/src/js/partialClient.js
@@ -1,7 +1,8 @@
-var BLACKBYTES_ASSET = require('ocore/constants').BLACKBYTES_ASSET;
-var balances = require('ocore/balances');
-var utils = require('../../angular-bitcore-wallet-client/bitcore-wallet-client/lib/common/utils');
-var fileSystem = require('./fileStorage');
+var safeRequire = require('./safeRequire');
+var BLACKBYTES_ASSET = safeRequire('ocore/constants').BLACKBYTES_ASSET;
+var balances = safeRequire('ocore/balances');
+var utils = safeRequire('../../angular-bitcore-wallet-client/bitcore-wallet-client/lib/common/utils');
+var fileSystem = safeRequire('./fileStorage');
 var completeClientLoaded = false;
 
 window.onerror = function (message) {

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1,7 +1,8 @@
 'use strict';
 
+
 var unsupported, isaosp;
-var breadcrumbs = require('ocore/breadcrumbs.js');
+var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
 
 if (window && window.navigator) {
   var rxaosp = window.navigator.userAgent.match(/Android.*AppleWebKit\/([\d.]+)/);

--- a/src/js/safeRequire.js
+++ b/src/js/safeRequire.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var BLOCKED_MODULES = [
+	'child_process', 'cluster', 'worker_threads', 'vm', 'dgram'
+];
+
+var ALLOWED_MODULES = [
+	'fs', 'path', 'crypto', 'os', 'events', 'stream', 'async',
+	'electron',
+	'bitcore-mnemonic', 'bitcore-lib', 'secp256k1', 'lodash',
+	'jszip', 'zip', 'unzipper', 'sqlite3', 'level-rocksdb',
+	'ocore/aa_addresses.js',
+	'ocore/aa_composer.js',
+	'ocore/aa_validation.js',
+	'ocore/arbiter_contract.js',
+	'ocore/arbiters.js',
+	'ocore/arbiters',
+	'ocore/balances',
+	'ocore/bots.js',
+	'ocore/breadcrumbs.js',
+	'ocore/chat_storage.js',
+	'ocore/composer.js',
+	'ocore/conf.js',
+	'ocore/conf',
+	'ocore/constants.js',
+	'ocore/constants',
+	'ocore/data_feeds.js',
+	'ocore/db.js',
+	'ocore/db',
+	'ocore/desktop_app.js',
+	'ocore/desktop_app',
+	'ocore/device.js',
+	'ocore/device',
+	'ocore/event_bus.js',
+	'ocore/formula/parse_ojson',
+	'ocore/indivisible_asset',
+	'ocore/kvstore',
+	'ocore/light_wallet.js',
+	'ocore/mutex.js',
+	'ocore/my_witnesses.js',
+	'ocore/my_witnesses',
+	'ocore/network.js',
+	'ocore/network',
+	'ocore/node_modules/secp256k1',
+	'ocore/object_hash.js',
+	'ocore/object_length.js',
+	'ocore/private_profile.js',
+	'ocore/prosaic_contract.js',
+	'ocore/signature.js',
+	'ocore/storage.js',
+	'ocore/string_utils.js',
+	'ocore/uri.js',
+	'ocore/validation_utils.js',
+	'ocore/validation.js',
+	'ocore/wallet_defined_by_addresses.js',
+	'ocore/wallet_defined_by_addresses',
+	'ocore/wallet_defined_by_keys.js',
+	'ocore/wallet_defined_by_keys',
+	'ocore/wallet_general.js',
+	'ocore/wallet_general',
+	'ocore/wallet.js',
+	'./fileStorage',
+	'./fileStorage.js',
+	'../../angular-bitcore-wallet-client/bitcore-wallet-client/lib/common/utils',
+	'../package.json',
+];
+
+var allowedSet = {};
+for (var i = 0; i < ALLOWED_MODULES.length; i++) {
+	allowedSet[ALLOWED_MODULES[i]] = true;
+}
+var blockedSet = {};
+for (var i = 0; i < BLOCKED_MODULES.length; i++) {
+	blockedSet[BLOCKED_MODULES[i]] = true;
+}
+
+var ALLOWED_DYNAMIC_PATTERNS = [/conf\.json$/];
+
+function safeRequire(moduleName) {
+	var clean = moduleName.replace(/['+\s]/g, '');
+	if (blockedSet[clean]) {
+		console.error('[safeRequire] BLOCKED:', moduleName);
+		return {};
+	}
+	if (allowedSet[moduleName] || allowedSet[clean])
+		return require(moduleName);
+	for (var i = 0; i < ALLOWED_DYNAMIC_PATTERNS.length; i++) {
+		if (ALLOWED_DYNAMIC_PATTERNS[i].test(clean))
+			return require(moduleName);
+	}
+	console.error('[safeRequire] Not whitelisted:', moduleName);
+	return {};
+}
+
+try {
+	if (module.id && module.id.indexOf('safeRequire') !== -1) {
+		module.exports = safeRequire;
+	}
+} catch(e) {}

--- a/src/js/services/aaDocService.js
+++ b/src/js/services/aaDocService.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.services').factory('aaDocService', function() {
 
 	var root = {};
@@ -18,7 +19,7 @@ angular.module('copayApp.services').factory('aaDocService', function() {
 			doc_url = doc_url.replace('ipfs://', 'https://ipfs.io/ipfs/');
 		if (docsByUrl[doc_url])
 			return handleDoc(docsByUrl[doc_url]);
-		require('ocore/uri.js').fetchUrl(doc_url, function (err, response) {
+		safeRequire('ocore/uri.js').fetchUrl(doc_url, function (err, response) {
 			if (err) {
 				console.log("fetching doc_url failed: " + err);
 				return handleDoc();

--- a/src/js/services/aliasValidationService.js
+++ b/src/js/services/aliasValidationService.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var ValidationUtils = require('ocore/validation_utils.js');
+
+var ValidationUtils = safeRequire('ocore/validation_utils.js');
 
 angular.module('copayApp.services').factory('aliasValidationService', function($timeout, configService, gettextCatalog) {
 
@@ -170,12 +171,12 @@ angular.module('copayApp.services').factory('aliasValidationService', function($
 			return setResult('none');
 		}
 
-		var conf = require('ocore/conf.js');
-		var db = require('ocore/db.js');
+		var conf = safeRequire('ocore/conf.js');
+		var db = safeRequire('ocore/db.js');
 		if (attestorKey === 'username') { // not an attestation, get from City state
 			const var_name = 'shortcode_' + value;
 			if (conf.bLight) {
-				const network = require('ocore/network.js');
+				const network = safeRequire('ocore/network.js');
 				const params = { address: attestorAddress, var_prefix: var_name };
 				network.requestFromLightVendor('light/get_aa_state_vars', params, function (ws, request, response) {
 					if (response.error) {
@@ -187,7 +188,7 @@ angular.module('copayApp.services').factory('aliasValidationService', function($
 				});
 			}
 			else {
-				const storage = require('ocore/storage.js');
+				const storage = safeRequire('ocore/storage.js');
 				storage.readAAStateVar(attestorAddress, var_name, address => {
 					setResult(address || "none");
 				})
@@ -214,7 +215,7 @@ angular.module('copayApp.services').factory('aliasValidationService', function($
 					return setResult('none');
 				}
 				// light
-				var network = require('ocore/network.js');
+				var network = safeRequire('ocore/network.js');
 				var params = {attestor_address: attestorAddress, field: obj.dbKey, value: value};
 				network.requestFromLightVendor('light/get_attestation', params, function (ws, request, response) {
 					if (response.error) {

--- a/src/js/services/applicationService.js
+++ b/src/js/services/applicationService.js
@@ -1,4 +1,5 @@
 'use strict';
+
 angular.module('copayApp.services')
   .factory('applicationService', function($rootScope, $timeout, isCordova, electron, go) {
     var root = {};
@@ -16,7 +17,7 @@ angular.module('copayApp.services')
         if (electron.isDefined()) {
           go.walletHome();
           $timeout(function() {
-            require('electron').remote.getCurrentWindow.reload();
+            safeRequire('electron').remote.getCurrentWindow.reload();
           }, 100);
         } else {
           window.location = window.location.href.substr(0, hashIndex);

--- a/src/js/services/autoUpdatingWitnessesList.js
+++ b/src/js/services/autoUpdatingWitnessesList.js
@@ -1,6 +1,7 @@
 'use strict';
 
 
+
 angular.module('copayApp.services')
 .factory('autoUpdatingWitnessesList', function($timeout, $modal, $rootScope, configService){
   var root = {};
@@ -11,8 +12,8 @@ angular.module('copayApp.services')
   root.checkChangeWitnesses = function(){
     if (!root.autoUpdate) return;
 
-	var device = require('ocore/device.js');
-	var myWitnesses = require('ocore/my_witnesses.js');
+	var device = safeRequire('ocore/device.js');
+	var myWitnesses = safeRequire('ocore/my_witnesses.js');
     device.getWitnessesFromHub(function(err, arrWitnessesFromHub){
       if (arrWitnessesFromHub) {
         myWitnesses.readMyWitnesses(function(arrWitnesses){

--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 angular.module('copayApp.services').factory('configService', function(storageService, lodash, $log, isCordova) {
   var root = {};
 
@@ -18,7 +19,7 @@ angular.module('copayApp.services').factory('configService', function(storageSer
 	  '#7A8C9E',
 	];
 
-  var constants = require('ocore/constants.js');
+  var constants = safeRequire('ocore/constants.js');
   var isTestnet = constants.version.match(/t$/);
   var isDevnet = constants.version.match(/dev$/);
   root.TIMESTAMPER_ADDRESS = isTestnet ? 'OPNUXBRSSQQGHKQNEPD2GLWQYEUY5XLD' : 'I2ADHGP4HL6J37NQAD73J7E5SKFIXJOT';
@@ -135,10 +136,10 @@ angular.module('copayApp.services').factory('configService', function(storageSer
 	],
 
 	// requires bluetooth permission on android
-	//deviceName: /*isCordova ? cordova.plugins.deviceName.name : */require('os').hostname(),
+	//deviceName: /*isCordova ? cordova.plugins.deviceName.name : */safeRequire('os').hostname(),
 
 	getDeviceName: function(){
-		return isCordova ? cordova.plugins.deviceName.name : require('os').hostname();
+		return isCordova ? cordova.plugins.deviceName.name : safeRequire('os').hostname();
 	},
 
 	// wallet default config

--- a/src/js/services/correspondentListService.js
+++ b/src/js/services/correspondentListService.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var constants = require('ocore/constants.js');
-var eventBus = require('ocore/event_bus.js');
-var ValidationUtils = require('ocore/validation_utils.js');
-var objectHash = require('ocore/object_hash.js');
+
+var constants = safeRequire('ocore/constants.js');
+var eventBus = safeRequire('ocore/event_bus.js');
+var ValidationUtils = safeRequire('ocore/validation_utils.js');
+var objectHash = safeRequire('ocore/object_hash.js');
 
 angular.module('copayApp.services').factory('correspondentListService', function($state, $rootScope, $sce, $compile, configService, storageService, profileService, go, lodash, $stickyState, $deepStateRedirect, $timeout, gettext, isCordova, pushNotificationsService, electron) {
 	var root = {};
-	var crypto = require('crypto');
-	var device = require('ocore/device.js');
-	var wallet = require('ocore/wallet.js');
-	var chatStorage = require('ocore/chat_storage.js');
+	var crypto = safeRequire('crypto');
+	var device = safeRequire('ocore/device.js');
+	var wallet = safeRequire('ocore/wallet.js');
+	var chatStorage = safeRequire('ocore/chat_storage.js');
 
 	$rootScope.newMessagesCount = {};
 	$rootScope.newMsgCounterEnabled = false;
@@ -18,7 +19,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	$rootScope.newPaymentsDetails = {};
 
 	if (electron.isDefined()) {
-		const electron = require('electron');
+		const electron = safeRequire('electron');
 		var messagesCount = 0;
 		var paymentsCount = 0;
 		electron.ipcRenderer.on('focus', function() {
@@ -58,7 +59,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 
 	
 	function addIncomingMessageEvent(from_address, in_body, message_counter){
-		var walletGeneral = require('ocore/wallet_general.js');
+		var walletGeneral = safeRequire('ocore/wallet_general.js');
 		walletGeneral.readMyPersonalAddresses(function(arrMyAddresses){
 			var body = highlightActions(escapeHtml(in_body), arrMyAddresses);
 			body.text = text2html(body.text);
@@ -169,7 +170,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	}
 
 	function highlightActions(text, arrMyAddresses){
-		var URI = require('ocore/uri.js');
+		var URI = safeRequire('ocore/uri.js');
 	//	return text.replace(/\b[2-7A-Z]{32}\b(?!(\?(amount|asset|device_address|base64data|from_address|single_address)|"))/g, function(address){
 		var params = [];
 		var param_index = -1;
@@ -208,7 +209,9 @@ angular.module('copayApp.services').factory('correspondentListService', function
 			if (!objPaymentRequest) {
 				return toDelayedReplacement(paymentDropdown(address));
 			}
-			return toDelayedReplacement('<a ng-click="sendPayment(\''+address+'\', '+objPaymentRequest.amount+', \''+objPaymentRequest.asset+'\', \''+objPaymentRequest.device_address+'\', \''+objPaymentRequest.base64data+'\', \''+objPaymentRequest.from_address+'\', \''+objPaymentRequest.single_address+'\''+(objPaymentRequest.additional_assets ? ', '+escapeQuotes(JSON.stringify(objPaymentRequest.additional_assets)) : '')+')">'+objPaymentRequest.amountStr+'</a>');
+			param_index++;
+			params[param_index] = {address: address, amount: objPaymentRequest.amount, asset: objPaymentRequest.asset, device_address: objPaymentRequest.device_address, base64data: objPaymentRequest.base64data, from_address: objPaymentRequest.from_address, single_address: objPaymentRequest.single_address, additional_assets: objPaymentRequest.additional_assets};
+			return toDelayedReplacement('<a ng-click="sendPaymentFromParams(messageEvent.message.params[' + param_index + '])">'+escapeHtml(objPaymentRequest.amountStr)+'</a>');
 		}).replace(pairing_regexp, function(str, uri, device_pubkey, hub, pairing_code){
 			param_index++;
 			params[param_index] = uri;
@@ -380,7 +383,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	function getPrivateProfileFromJsonBase64(privateProfileJsonBase64){
 		if (!ValidationUtils.isValidBase64(privateProfileJsonBase64))
 			return null;
-		var privateProfile = require('ocore/private_profile.js');
+		var privateProfile = safeRequire('ocore/private_profile.js');
 		var objPrivateProfile = privateProfile.getPrivateProfileFromJsonBase64(privateProfileJsonBase64);
 		if (!objPrivateProfile)
 			return null;
@@ -425,7 +428,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 			objSignedMessage: objSignedMessage,
 			bValid: undefined
 		};
-		var validation = require('ocore/validation.js');
+		var validation = safeRequire('ocore/validation.js');
 		validation.validateSignedMessage(objSignedMessage, function(err){
 			info.bValid = !err;
 			if (err)
@@ -463,7 +466,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	}
 	
 	function formatOutgoingMessage(text){
-		var URI = require('ocore/uri.js');
+		var URI = safeRequire('ocore/uri.js');
 		var assocReplacements = {};
 		var index = crypto.randomBytes(4).readUInt32BE(0);
 		var params = [];
@@ -551,7 +554,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	function parsePaymentRequestQueryString(query_string){
 		if (!query_string)
 			return null;
-		var URI = require('ocore/uri.js');
+		var URI = safeRequire('ocore/uri.js');
 		var assocParams = URI.parseQueryString(query_string, '&amp;');
 		var strAmount = assocParams['amount'];
 		if (!strAmount)
@@ -609,7 +612,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	}
 	
 	function escapeHtml(text){
-		return text.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+		return text.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 	}
 	
 	function escapeHtmlAndInsertBr(text){
@@ -783,7 +786,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 			for (var i in messages) {
 				messages[i] = parseMessage(messages[i]);
 			}
-			var walletGeneral = require('ocore/wallet_general.js');
+			var walletGeneral = safeRequire('ocore/wallet_general.js');
 			walletGeneral.readMyPersonalAddresses(function(arrMyAddresses){
 				if (messages.length < limit)
 					historyEndForCorrespondent[correspondent.device_address] = true;
@@ -943,8 +946,8 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	});
 
 	eventBus.on('new_my_transactions', (arrNewUnits) => {
-		var storage = require('ocore/storage.js');
-		var db = require('ocore/db.js');
+		var storage = safeRequire('ocore/storage.js');
+		var db = safeRequire('ocore/db.js');
 			
 		arrNewUnits.forEach((unit) => {
 			if (unit === $rootScope.sentUnit)

--- a/src/js/services/correspondentService.js
+++ b/src/js/services/correspondentService.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var constants = require("ocore/constants.js");
-var eventBus = require("ocore/event_bus.js");
-var ValidationUtils = require("ocore/validation_utils.js");
-var objectHash = require("ocore/object_hash.js");
+var constants = safeRequire("ocore/constants.js");
+var eventBus = safeRequire("ocore/event_bus.js");
+var ValidationUtils = safeRequire("ocore/validation_utils.js");
+var objectHash = safeRequire("ocore/object_hash.js");
 
 angular.module("copayApp.services").factory("correspondentService", function($rootScope, $modal, $timeout, go, animationService, configService, profileService, lodash, txFormatService, correspondentListService, notification, gettext, isCordova, electron) {
 	var root = {};
-	var device = require("ocore/device.js");
-	var chatStorage = require("ocore/chat_storage.js");
-	var wallet_general = require('ocore/wallet_general.js');
-	var arbiter_contract = require("ocore/arbiter_contract.js");
-	var arbiters = require("ocore/arbiters.js");
-	var storage = require("ocore/storage.js");
+	var device = safeRequire("ocore/device.js");
+	var chatStorage = safeRequire("ocore/chat_storage.js");
+	var wallet_general = safeRequire('ocore/wallet_general.js');
+	var arbiter_contract = safeRequire("ocore/arbiter_contract.js");
+	var arbiters = safeRequire("ocore/arbiters.js");
+	var storage = safeRequire("ocore/storage.js");
 
 	function populateScopeWithAttestedFields(scope, my_address, peer_address, cb) {
-		var privateProfile = require("ocore/private_profile.js");
+		var privateProfile = safeRequire("ocore/private_profile.js");
 		scope.my_name = "NAME NOT VERIFIED";
 		scope.my_attestor = {};
 		scope.peer_name = "NAME NOT VERIFIED";
@@ -64,7 +64,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 	}
 
 	function listenForProsaicContractResponse(contracts) {
-		var prosaic_contract = require("ocore/prosaic_contract.js");
+		var prosaic_contract = safeRequire("ocore/prosaic_contract.js");
 
 		var showError = function(msg) {
 			$rootScope.$emit("Local/ShowErrorAlert", msg);
@@ -112,7 +112,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 								device_address: contract.peer_device_address
 							}
 						};
-						require("ocore/wallet_defined_by_addresses.js").createNewSharedAddress(arrDefinition, assocSignersByPath, {
+						safeRequire("ocore/wallet_defined_by_addresses.js").createNewSharedAddress(arrDefinition, assocSignersByPath, {
 							ifError: function(err){
 								showError(err);
 							},
@@ -297,11 +297,11 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 		}
 	});
 
-	var db = require("ocore/db.js");
+	var db = safeRequire("ocore/db.js");
 	
 	function readLastMainChainIndex(cb){
-		if (require("ocore/conf.js").bLight){
-			require("ocore/network.js").requestFromLightVendor("get_last_mci", null, function(ws, request, response){
+		if (safeRequire("ocore/conf.js").bLight){
+			safeRequire("ocore/network.js").requestFromLightVendor("get_last_mci", null, function(ws, request, response){
 				response.error ? cb(response.error) : cb(null, response);
 			});
 		}
@@ -313,7 +313,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 
 	function showProsaicContractOfferModal($scope, hash, isIncoming, getSigningDeviceAddresses){
 		$rootScope.modalOpened = true;
-		var prosaic_contract = require("ocore/prosaic_contract.js");
+		var prosaic_contract = safeRequire("ocore/prosaic_contract.js");
 		prosaic_contract.getByHash(hash, function(objContract){
 			if (!objContract)
 				throw Error("no contract found in database for already received offer message");
@@ -374,7 +374,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 							if (objContract.status !== "pending")
 								return setError("contract status has changed, reopen it");
 							prosaic_contract.setField(objContract.hash, "status", status);
-							prosaic_contract.respond(objContract, status, signedMessageBase64, require("ocore/wallet.js").getSigner());
+							prosaic_contract.respond(objContract, status, signedMessageBase64, safeRequire("ocore/wallet.js").getSigner());
 							objContract.status = status;
 							var chat_message = "(prosaic-contract:" + Buffer.from(JSON.stringify(objContract), "utf8").toString("base64") + ")";
 							var body = correspondentListService.formatOutgoingMessage(chat_message);
@@ -594,7 +594,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 									});
 								});
 							};
-							require("ocore/wallet.js").readAssetMetadata([$scope.asset], applyNewAssetMetadata, function (bUpdated, assetMetadata) {
+							safeRequire("ocore/wallet.js").readAssetMetadata([$scope.asset], applyNewAssetMetadata, function (bUpdated, assetMetadata) {
 								if (bUpdated)
 									applyNewAssetMetadata(assetMetadata);
 							});
@@ -636,7 +636,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 						});
 					}
 					// hide "claim funds" button if not enough balance on the contract (already claimed)
-					require("ocore/wallet.js").readBalance(objContract.shared_address, function(balances) {
+					safeRequire("ocore/wallet.js").readBalance(objContract.shared_address, function(balances) {
 						var asset = objContract.asset || 'base';
 						if (!balances[asset] || balances[asset].total < objContract.amount)
 							$scope.funds_claimed = true;
@@ -702,7 +702,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 					};
 
 					var respond = function(status, signedMessageBase64) {
-						arbiter_contract.respond(objContract.hash, status, signedMessageBase64, require("ocore/wallet.js").getSigner(), function(err, objContract) {
+						arbiter_contract.respond(objContract.hash, status, signedMessageBase64, safeRequire("ocore/wallet.js").getSigner(), function(err, objContract) {
 							if (err)
 								return setError(err);
 							addContractEventIntoChat(objContract, 'event', false);
@@ -895,7 +895,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 							if (err)
 								return setError(err);
 							
-							require("ocore/arbiters").getInfo(objContract.arbiter_address, function(err, objArbiter) {
+							safeRequire("ocore/arbiters").getInfo(objContract.arbiter_address, function(err, objArbiter) {
 								stop_loading();
 								if (err) {
 									return setError(err);
@@ -1127,7 +1127,7 @@ angular.module("copayApp.services").factory("correspondentService", function($ro
 							});
 						}
 					};
-					require("ocore/wallet.js").readAssetMetadata([$scope.asset], applyNewAssetMetadata, function (bUpdated, assetMetadata) {
+					safeRequire("ocore/wallet.js").readAssetMetadata([$scope.asset], applyNewAssetMetadata, function (bUpdated, assetMetadata) {
 						if (bUpdated)
 							applyNewAssetMetadata(assetMetadata);
 					});

--- a/src/js/services/electronService.js
+++ b/src/js/services/electronService.js
@@ -1,10 +1,11 @@
 'use strict';
 
+
 angular.module('copayApp.services').factory('electron', function electronFactory() {
 	var root = {};
 	let electron;
 	try {
-		electron = require('electron');
+		electron = safeRequire('electron');
 	}
 	catch(e){}
 

--- a/src/js/services/fileStorage.js
+++ b/src/js/services/fileStorage.js
@@ -1,8 +1,9 @@
 'use strict';
 
+
 angular.module('copayApp.services')
   .factory('fileStorageService', function() {
-    var fileStorage = require('./fileStorage.js');
+    var fileStorage = safeRequire('./fileStorage.js');
     var root = {};
     
     root.get = function(k, cb) {

--- a/src/js/services/fileSystem.js
+++ b/src/js/services/fileSystem.js
@@ -1,14 +1,15 @@
 'use strict';
 
+
 angular.module('copayApp.services')
 .factory('fileSystemService', function($log, isCordova) {
-	var async = require('async');
+	var async = safeRequire('async');
 	var root = {},
 		bFsInitialized = false;
 	
 	try {
-		var fs = require('fs');
-		var desktopApp = require('ocore/desktop_app.js' + '');
+		var fs = safeRequire('fs');
+		var desktopApp = safeRequire('ocore/desktop_app.js' + '');
 	} catch (e) {
 		
 	}
@@ -290,7 +291,7 @@ angular.module('copayApp.services')
 	};
 
 	root.recursiveMkdir = function(path, mode, callback) {
-		var parentDir = require('path' + '').dirname(path);
+		var parentDir = safeRequire('path' + '').dirname(path);
 		
 		fs.stat(parentDir, function(err, stats) {
 			if (err && err.code !== 'ENOENT')

--- a/src/js/services/go.js
+++ b/src/js/services/go.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var eventBus = require('ocore/event_bus.js');
+
+var eventBus = safeRequire('ocore/event_bus.js');
 
 angular.module('copayApp.services').factory('go', function($window, $rootScope, $timeout, $location, $state, profileService, fileSystemService, notification, gettextCatalog, authService, $deepStateRedirect, $stickyState, configService, isCordova) {
 	var root = {};
 
 	let electron;
 	try {
-		electron = require('electron');
+		electron = safeRequire('electron');
 	}
 	catch(e){}
 
@@ -39,6 +40,16 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 
 	root.openExternalLink = function(url) {
 		url = url.replace(/&amp;/g, '&');
+		try {
+			var parsed = new URL(url);
+			if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+				console.warn('Blocked non-http URL:', url);
+				return;
+			}
+		} catch(e) {
+			console.warn('Blocked invalid URL:', url);
+			return;
+		}
 		if (electron)
 			electron.shell.openExternal(url);
 		else if (isCordova)
@@ -119,7 +130,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 
 
 	function handleUri(uri){
-		var conf = require('ocore/conf.js');
+		var conf = safeRequire('ocore/conf.js');
 		var bb_program_url = new RegExp('^'+conf.program+':', 'i');
 		var ob_program_url = new RegExp('^'+conf.program.replace(/byteball/i, 'obyte')+':', 'i');
 		var ob_url = new RegExp('^obyte:', 'i');
@@ -127,7 +138,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 
 		console.log("handleUri "+uri);
 
-		require('ocore/uri.js').parseUri(uri, {
+		safeRequire('ocore/uri.js').parseUri(uri, {
 			ifError: function (err) {
 				console.log(err);
 				$rootScope.$emit('Local/ShowErrorAlert', err);
@@ -143,7 +154,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 						}
 						if (!objRequest.from_address)
 							return emitPaymentRequest();
-						var db = require('ocore/db.js');
+						var db = safeRequire('ocore/db.js');
 						db.query("SELECT address, wallet FROM my_addresses WHERE address=?", [objRequest.from_address], function (rows) {
 							$timeout(function () {
 								if (rows.length === 0)
@@ -196,7 +207,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 			return;
 		}
 		last_handle_file_ts = Date.now();
-		var breadcrumbs = require('ocore/breadcrumbs.js');
+		var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
 		console.log("handleFile "+uri);
 		root.walletHome();
 		$rootScope.$emit('process_status_change', 'claiming', true);
@@ -212,20 +223,20 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 		if (uri.indexOf("content:") !== -1) {
 			window.plugins.intent.readFileFromContentUrl(uri.replace(/#/g,'%23'), function (content) {
 				breadcrumbs.add("handleFile - content url");
-				require('ocore/wallet.js').handlePrivatePaymentFile(null, content, cb);
+				safeRequire('ocore/wallet.js').handlePrivatePaymentFile(null, content, cb);
 			}, function (err) {throw err});
 			return checkDoubleClaim();
 		}
 		if (uri.indexOf("." + configService.privateTextcoinExt) != -1) {
 			breadcrumbs.add("handleFile - file path url");
-			require('ocore/wallet.js').handlePrivatePaymentFile(uri, null, cb);
+			safeRequire('ocore/wallet.js').handlePrivatePaymentFile(uri, null, cb);
 			return checkDoubleClaim();
 		}
 		$rootScope.$emit('process_status_change', 'claiming', false);
 	}
 	
 	function extractObyteArgFromCommandLine(commandLine){
-		var conf = require('ocore/conf.js');
+		var conf = safeRequire('ocore/conf.js');
 		var bb_url = new RegExp('^'+conf.program+':', 'i');
 		var ob_url = new RegExp('^'+conf.program.replace(/byteball/i, 'obyte')+':', 'i');
 		var file = new RegExp("\\."+configService.privateTextcoinExt+'$', 'i');
@@ -267,7 +278,7 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 	}
 
 	function createLinuxDesktopFile(){
-		var path = require('path'+'');
+		var path = safeRequire('path'+'');
 		if (process.env.APPIMAGE){
 			console.log("run from appimage " + process.env.APPIMAGE);
 			var execPath = process.env.APPIMAGE;
@@ -288,10 +299,10 @@ angular.module('copayApp.services').factory('go', function($window, $rootScope, 
 			var iconPath = path.dirname(execPath)+"/public/img/icons/logo-circle-256.png";
 		}
 		console.log("will write .desktop file");
-		var fs = require('fs'+'');
-		var child_process = require('child_process'+'');
-		var package_json = require('../package.json'+''); // relative to html root
-		var conf = require('ocore/conf.js');
+		var fs = safeRequire('fs');
+		var package_json = safeRequire('../package.json');
+		var conf = safeRequire('ocore/conf.js');
+		var ipcRenderer = safeRequire('electron').ipcRenderer;
 		var applicationsDir = process.env.HOME + '/.local/share/applications';
 		var mimeDir = process.env.HOME + '/.local/share/mime';
 		fileSystemService.recursiveMkdir(applicationsDir, parseInt('700', 8), function(err){
@@ -310,9 +321,7 @@ X-Ubuntu-Touch=true\n\
 X-Ubuntu-StageHint=SideStage\n", {mode: parseInt('755', 8)}, function(err){
 				if (err)
 					throw Error("failed to write desktop file: "+err);
-				child_process.exec('update-desktop-database '+applicationsDir, function(err){
-					if (err)
-						throw Error("failed to exec update-desktop-database: "+err);
+				ipcRenderer.invoke('desktop:exec', 'update-desktop-database '+applicationsDir).then(function(){
 					var writeXml = function() {
 						fs.writeFile(mimeDir + '/packages/' + conf.program+'.xml', "<?xml version=\"1.0\"?>\n\
 	 <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>\n\
@@ -323,10 +332,8 @@ X-Ubuntu-StageHint=SideStage\n", {mode: parseInt('755', 8)}, function(err){
 	 </mime-info>\n", {mode: parseInt('755', 8)}, function(err) {
 	 						if (err)
 								throw Error("failed to write MIME config file: "+err);
-							child_process.exec('update-mime-database '+mimeDir, function(err){
-								if (err)
-									throw Error("failed to exec update-mime-database: "+err);
-								child_process.exec('xdg-icon-resource install --context mimetypes --size 64 '+path.dirname(execPath)+'/public/img/icons/logo-circle-64.png application-x-'+conf.program, function(err){});
+							ipcRenderer.invoke('desktop:exec', 'update-mime-database '+mimeDir).then(function(){
+								ipcRenderer.invoke('desktop:exec', 'xdg-icon-resource install --context mimetypes --size 64 '+path.dirname(execPath)+'/public/img/icons/logo-circle-64.png application-x-'+conf.program);
 							});
 	 						console.log(".desktop done");
 	 					});

--- a/src/js/services/newVersion.js
+++ b/src/js/services/newVersion.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var eventBus = require('ocore/event_bus.js');
+
+var eventBus = safeRequire('ocore/event_bus.js');
 
 angular.module('copayApp.services')
 .factory('newVersion', function($modal, $timeout, $rootScope){

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var breadcrumbs = require('ocore/breadcrumbs.js');
-var constants = require('ocore/constants.js');
+
+var breadcrumbs = safeRequire('ocore/breadcrumbs.js');
+var constants = safeRequire('ocore/constants.js');
 
 angular.module('copayApp.services')
   .factory('profileService', function profileServiceFactory($rootScope, $location, $timeout, $filter, $log, lodash, storageService, bwcService, configService, pushNotificationsService, isCordova, gettext, gettextCatalog, uxLanguage) {
@@ -191,12 +192,12 @@ angular.module('copayApp.services')
                     return cb(err);
                 root._setFocus(focusedWalletId, function() {
                     console.log("focusedWalletId", focusedWalletId);
-					var Wallet = require('ocore/wallet.js');
-					var device = require('ocore/device.js');
+					var Wallet = safeRequire('ocore/wallet.js');
+					var device = safeRequire('ocore/device.js');
                     var config = configService.getSync();
                     var firstWc = root.walletClients[lodash.keys(root.walletClients)[0]];
                     // set light_vendor_url here as we may request new assets history at startup during balances update
-                    require('ocore/light_wallet.js').setLightVendorHost(config.hub);
+                    safeRequire('ocore/light_wallet.js').setLightVendorHost(config.hub);
                     if (root.profile.xPrivKeyEncrypted){
                         console.log('priv key is encrypted, will wait for UI and request password');
                         // assuming bindProfile is called on encrypted keys only at program startup
@@ -329,10 +330,10 @@ angular.module('copayApp.services')
             if (err)
                 return cb(err);
             var config = configService.getSync();
-			require('ocore/wallet.js'); // load hub/ message handlers
-			var device = require('ocore/device.js');
+			safeRequire('ocore/wallet.js'); // load hub/ message handlers
+			var device = safeRequire('ocore/device.js');
             var tempDeviceKey = device.genPrivKey();
-            require('ocore/light_wallet.js').setLightVendorHost(config.hub);
+            safeRequire('ocore/light_wallet.js').setLightVendorHost(config.hub);
 			// initDeviceProperties sets my_device_address needed by walletClient.createWallet
 			walletClient.initDeviceProperties(walletClient.credentials.xPrivKey, null, config.hub, config.deviceName);
             var walletName = gettextCatalog.getString('Small Expenses Account');
@@ -370,7 +371,7 @@ angular.module('copayApp.services')
 			});
 			return console.log('need password to create new wallet');
 		}
-		var walletDefinedByKeys = require('ocore/wallet_defined_by_keys.js');
+		var walletDefinedByKeys = safeRequire('ocore/wallet_defined_by_keys.js');
         walletDefinedByKeys.readNextAccount(function(account){
             console.log("next account = "+account);
             if (!opts.extendedPrivateKey && !opts.mnemonic){
@@ -756,7 +757,7 @@ angular.module('copayApp.services')
 	};
 		
 	root.replaceProfile = function (xPrivKey, mnemonic, myDeviceAddress, cb) {
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		
 		root.profile.credentials = [];
 		root.profile.xPrivKey = xPrivKey;

--- a/src/js/services/pushNotificationsService.js
+++ b/src/js/services/pushNotificationsService.js
@@ -1,4 +1,5 @@
 'use strict';
+
 angular.module('copayApp.services')
 .factory('pushNotificationsService', function($http, $rootScope, $log, isMobile, $timeout, storageService, configService, lodash, isCordova) {
 	var root = {};
@@ -8,10 +9,10 @@ angular.module('copayApp.services')
 	var _ws;
 	var push;
 	
-	var eventBus = require('ocore/event_bus.js');
+	var eventBus = safeRequire('ocore/event_bus.js');
 	
 	function sendRequestEnableNotification(ws, registrationId) {
-		var network = require('ocore/network.js');
+		var network = safeRequire('ocore/network.js');
 		network.sendRequest(ws, 'hub/enable_notification', {registrationId: registrationId, platform: isMobile.iOS() ? 'ios' : 'android'}, false, function(ws, request, response) {
 			if (!response || (response && response !== 'ok')) return $log.error('Error sending push info');
 		});
@@ -52,7 +53,7 @@ angular.module('copayApp.services')
 	root.pushNotificationsInit = function() {
 		if (!usePushNotifications) return;
 		
-		var device = require('ocore/device.js');
+		var device = safeRequire('ocore/device.js');
 		device.readCorrespondents(function(devices){
 			if (devices.length == 0)
 				return;
@@ -91,7 +92,7 @@ angular.module('copayApp.services')
 			if (err)
 				return $log.error('Error getting push info');
 			storageService.removePushInfo(function() {
-				var network = require('ocore/network.js');
+				var network = safeRequire('ocore/network.js');
 				network.sendRequest(_ws, 'hub/disable_notification', pushInfo.registrationId, false, function(ws, request, response) {
 					if (!response || (response && response !== 'ok')) return $log.error('Error sending push info');
 				});

--- a/src/js/services/rocksdbStorage.js
+++ b/src/js/services/rocksdbStorage.js
@@ -1,16 +1,17 @@
 'use strict';
 
+
 angular.module('copayApp.services')
   .factory('rocksdbStorageService', function($timeout, isCordova) {
     if (isCordova) {
       console.log('rocksdbStorageService is not available on mobile devices');
       return {};
     }
-  	var desktopApp = require('ocore/desktop_app.js');
+  	var desktopApp = safeRequire('ocore/desktop_app.js');
     var root = {};
     var walletDataDir = 'walletdata';
     var path = desktopApp.getAppDataDir() + '/' + walletDataDir;
-    var level = require('level-rocksdb');
+    var level = safeRequire('level-rocksdb');
     if (process.platform === 'win32') {
 		process.chdir(desktopApp.getAppDataDir()); // workaround non-latin characters in path
 		path = walletDataDir;

--- a/src/js/services/txFormatService.js
+++ b/src/js/services/txFormatService.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var constants = require('ocore/constants.js');
+
+var constants = safeRequire('ocore/constants.js');
 
 angular.module('copayApp.services').factory('txFormatService', function(profileService, configService, lodash) {
   var root = {};


### PR DESCRIPTION
Companion to #683. Hardens the renderer process against code injection and adds more comprehensive security fixes across the app.

- **Chat sanitizer**: escapeHtml() now escapes quotes. The dynamic directive strips all ng-* attributes except a whitelist of the 19 known-safe ng-click functions (sendPayment, handleUri, etc.) before $compile runs.
- **safeRequire()**: Drop-in replacement for require() across 296 call sites. Only allows the 66 modules the app actually uses — everything else returns an empty stub.
- **CSP**: Added Content-Security-Policy meta tag blocking inline scripts and javascript: URIs.
- **IPC for child_process**: Linux .desktop registration moved from direct child_process.exec() to a main-process IPC handler with command whitelisting.
- **URL validation**: shell.openExternal() calls now reject non-http(s) protocols.

All wallet functionality (payments, bot commands, contracts, pairing, signing) should be working normally.